### PR TITLE
Added plugin for RabbitMQ using amqplib, and added support for user and password to queue/rabbitmq

### DIFF
--- a/config/rabbitmq_amqplib.ini
+++ b/config/rabbitmq_amqplib.ini
@@ -1,0 +1,12 @@
+[rabbitmq]
+host = localhost
+port = 5672
+user = guest
+password = guest
+exchangeName  = email_messages
+exchangeType = direct
+queueName = emails
+deliveryMode = 2
+confirm = true
+durable = true
+autoDelete = false

--- a/docs/plugins/queue/rabbitmq.md
+++ b/docs/plugins/queue/rabbitmq.md
@@ -18,6 +18,9 @@ Configuration
         ; ip and port of the server.
         server_ip = localhost
         server_port = 5672
+        ; user and password
+        user = guest
+        password = guest
         ; name of the queue which reader will read
         queueName = email
         ; This is for making it persistant while publishing message

--- a/docs/plugins/queue/rabbitmq_amqplib.md
+++ b/docs/plugins/queue/rabbitmq_amqplib.md
@@ -1,0 +1,35 @@
+queue/rabbitmq_amqplib
+======================
+
+This plugin delivers emails to RabbitMQ queue for further processing. Based on `queue/rabbitmq` but using `amqplib`.
+
+Dependency
+----------
+* `amqplib` - https://github.com/squaremo/amqp.node
+
+Configuration
+-------------
+
+* `config/rabbitmq_amqplib.ini` - Connection, exchange and queue settings
+    
+    Example:
+
+    
+        [rabbitmq]
+        ; Connection
+		host = localhost
+		port = 5672
+		user = guest
+		password = guest
+		; Exchange
+		exchangeName  = email_messages
+		exchangeType = direct
+		; Queue
+		queueName = emails
+		deliveryMode = 2
+		confirm = true
+		durable = true
+		autoDelete = false
+
+    
+ More information about RabbitMQ can be found at https://www.rabbitmq.com/

--- a/plugins/queue/rabbitmq.js
+++ b/plugins/queue/rabbitmq.js
@@ -64,8 +64,7 @@ exports.init_rabbitmq_server = function() {
     //Read the config file rabbitmq
     var config     = plugin.config.get('rabbitmq.ini');
     //Just putting the defaults
-    var rabbitmq_ip  = '127.0.0.1';
-    var rabbitmq_port = '5672';
+    var options = {};
     var confirm = true;
     var durable = true;
     var autoDelete = false;
@@ -73,8 +72,10 @@ exports.init_rabbitmq_server = function() {
 
     //Getting the values from config file rabbitmq.ini
     if (config.rabbitmq) {
-        rabbitmq_ip = config.rabbitmq.server_ip || '127.0.0.1';
-        rabbitmq_port = config.rabbitmq.server_port || '5672';
+        options['host'] = config.rabbitmq.server_ip || '127.0.0.1';
+        options['port'] = config.rabbitmq.server_port || '5672';
+        options['login'] = config.rabbitmq.user || 'guest';
+        options['password'] = config.rabbitmq.password || 'guest';
         exchangeName = config.rabbitmq.exchangeName || 'emailMessages';
         exchangeType = config.rabbitmq.exchangeType || 'direct';
         confirm = config.rabbitmq.confirm === 'true'|| true;
@@ -94,7 +95,7 @@ exports.init_rabbitmq_server = function() {
 
     //Create connection to the rabbitmq server
     logger.logdebug("About to Create connection with server");
-    rabbitqueue = amqp.createConnection({ host: rabbitmq_ip , port : rabbitmq_port });
+    rabbitqueue = amqp.createConnection(options);
 
 
     //Declaring listerner on error on connection.

--- a/plugins/queue/rabbitmq_amqplib.js
+++ b/plugins/queue/rabbitmq_amqplib.js
@@ -1,0 +1,56 @@
+// queue/rabbitmq_amqplib
+
+var amqp = require("amqplib/callback_api");
+
+var channel,
+    queue,
+    deliveryMode;
+
+exports.register = function () {
+    this.init_amqp_connection();
+}
+
+exports.hook_queue = function(next, connection) {
+    connection.transaction.message_stream.get_data(function(str) {
+        if (channel.sendToQueue(queue, new Buffer(str), {deliveryMode: deliveryMode}))
+            return next(OK);
+        else
+            return next();
+    });
+};
+
+exports.init_amqp_connection = function() {
+    var cfg = this.config.get("rabbitmq.ini").rabbitmq;
+
+    var host = cfg.host || "127.0.0.1",
+        port = cfg.port || "5672",
+        user = cfg.user || "guest",
+        password = cfg.password || "guest",
+        exchangeName = cfg.exchangeName || "emailMessages",
+        exchangeType = cfg.exchangeType || "direct",
+        queueName = cfg.queueName || "emails",
+        durable = cfg.durable === "true" || true,
+        // confirm = cfg.confirm === "true" || true,
+        autoDelete = cfg.autoDelete === "true" || false;
+        deliveryMode = cfg.deliveryMode || 2;
+
+    amqp.connect("amqp://"+user+":"+password+"@"+host+":"+port, function(err, conn){
+        if(err) 
+            return conn.close();
+        // TODO: if !confirm conn.createChannel...
+        conn.createConfirmChannel(function (err, ch) {
+            if(err) 
+                return conn.close();
+            ch.assertExchange(exchangeName, exchangeType, {durable: durable}, function(err, ok){
+                if(err) 
+                    return conn.close();
+                ch.assertQueue(queueName, {durable: durable, autoDelete: autoDelete}, function(err, ok){
+                    if(err)
+                        return conn.close();
+                    queue = ok.queue;
+                    channel = ch;
+                });
+            });
+        });
+    });
+};


### PR DESCRIPTION
The first commit is for the plugin `queue/rabbitmq` that depends of `amqp` package. I added settings to specify user and password for the connection with RabbitMQ.
The second commit is a new plugin similar to `queue/rabbitmq` but depends of `amqplib` package. I wrote this plugin for people who want to use the package `amqplib` not to replace the default plugin for RabbitMQ.