### PR TITLE
prevent replace \r\n

### DIFF
--- a/outbound.js
+++ b/outbound.js
@@ -383,7 +383,7 @@ exports.send_email = function () {
     var re = /^([^\n]*\n?)/;
     while (match = re.exec(contents)) {
         var line = match[1];
-        line = line.replace(/\n?$/, '\r\n'); // make sure it ends in \r\n
+        line = line.replace(/\r\n|\n?$/, '\r\n'); // make sure it ends in \r\n
         transaction.add_data(new Buffer(line));
         contents = contents.substr(match[1].length);
         if (contents.length === 0) {


### PR DESCRIPTION
If we pass a content which already has \r\n on every line – libs like Mailcomposer (https://github.com/andris9/mailcomposer) already set it – the email will end up in an invalid format.