### PR TITLE
GeoIP & ASN

### DIFF
--- a/plugins/connect.asn.js
+++ b/plugins/connect.asn.js
@@ -45,8 +45,13 @@ exports.load_asn_ini = function () {
         plugin.load_asn_ini();
     });
 
-    if (plugin.cfg.main.providers) {
-        conf_providers = plugin.cfg.main.providers.split(/[\s,;]+/);
+    if (plugin.cfg.main.providers !== undefined) {  // defined
+        if (plugin.cfg.main.providers === '') {   // and not empty
+            conf_providers = [];
+        }
+        else {
+            conf_providers = plugin.cfg.main.providers.split(/[\s,;]+/);
+        }
     }
     if (plugin.cfg.main.test_ip) {
         test_ip = plugin.cfg.main.test_ip;

--- a/plugins/connect.asn.js
+++ b/plugins/connect.asn.js
@@ -10,6 +10,7 @@ var conf_providers = [ 'origin.asn.cymru.com', 'asn.routeviews.org' ];
 
 exports.register = function () {
     var plugin = this;
+    plugin.registered = false;
 
     plugin.load_asn_ini();
 
@@ -26,6 +27,10 @@ exports.register = function () {
 
         plugin.loginfo(plugin, zone + " succeeded");
         if (providers.indexOf(zone) === -1) providers.push(zone);
+
+        if (plugin.registered) return;
+        plugin.registered = true;
+        plugin.register_hook('lookup_rdns', 'lookup_asn');
     };
 
     // test each provider
@@ -94,7 +99,7 @@ exports.get_dns_results = function (zone, ip, done) {
     });
 };
 
-exports.hook_lookup_rdns = function (next, connection) {
+exports.lookup_asn = function (next, connection) {
     var plugin = this;
     var ip = connection.remote_ip;
     if (net_utils.is_rfc1918(ip)) return next();

--- a/plugins/connect.geoip.js
+++ b/plugins/connect.geoip.js
@@ -120,6 +120,11 @@ exports.lookup_maxmind = function (next, connection) {
     if (asn) {
         var match = asn.match(/^(?:AS)([0-9]+)\s+(.*)$/);
         if (match) {
+            connection.results.add({name: 'connect.asn'},
+                { geoip: match,
+                    asn: match[1],
+                    asn_org: match[2]
+                });
             connection.results.add(plugin, {asn: match[1]});
             connection.results.add(plugin, {asn_org: match[2]});
         }


### PR DESCRIPTION
* asn: permit asn plugin to have 0 providers
* asn: only register lookup_rdns hook if a provider is available
* geoip: emit log entry of ASN results, when found
* geoip: moved ASN lookup into it's own function

The net change is that the geoip plugin now emits a log entry like this:
````
[connect.geoip] asn: 53264, org: Continuum Data Centers, LLC.
````