### PR TITLE
Fix Txn.attachment_hooks to defer body creation like similar methods

### DIFF
--- a/tests/transaction.js
+++ b/tests/transaction.js
@@ -1,0 +1,51 @@
+var stub         = require('./fixtures/stub'),
+    configfile   = require('./../configfile'), // To prevent compile errors in transaction.js.
+    Transaction  = require('../transaction');
+
+function _set_up(callback) {
+    this.transaction = Transaction.createTransaction();
+    callback();
+}
+
+function _tear_down(callback) {
+    callback();
+}
+
+exports.transaction = {
+    setUp : _set_up,
+    tearDown : _tear_down,
+
+    'add_body_filter': function (test) {
+        var self = this;
+
+        test.expect(3);
+
+        this.transaction.add_body_filter('text/plain', function (ct, enc, buf) {
+            // The actual functionality of these filter functions is tested in
+            // mailbody.js.  This just makes sure the plumbing is in place.
+
+            test.ok(ct.indexOf('text/plain') === 0, "correct body part");
+            test.ok(/utf-?8/i.test(enc), "correct encoding");
+            test.equal(buf.toString().trim(), "Text part", "correct body contents");
+        });
+
+        [
+            "Content-Type: multipart/alternative; boundary=abcd\n",
+            "\n",
+            "--abcd\n",
+            "Content-Type: text/plain\n",
+            "\n",
+            "Text part\n",
+            "--abcd\n",
+            "Content-Type: text/html\n",
+            "\n",
+            "<p>HTML part</p>\n",
+            "--abcd--\n",
+        ].forEach(function (line) {
+            self.transaction.add_data(line);
+        });
+        this.transaction.end_data(function () {
+            test.done();
+        });
+    },
+};

--- a/tests/transaction.js
+++ b/tests/transaction.js
@@ -48,4 +48,29 @@ exports.transaction = {
             test.done();
         });
     },
+
+    'regression: attachment_hooks before set_banner/add_body_filter': function (test) {
+        var self = this;
+
+        test.expect(2);
+
+        this.transaction.attachment_hooks(function () {});
+        this.transaction.set_banner('banner');
+        this.transaction.add_body_filter('', function () {
+            test.ok(true, "body filter called");
+        });
+        [
+            "Content-Type: text/plain\n",
+            "\n",
+            "Some text\n",
+        ].forEach(function (line) {
+            self.transaction.add_data(line);
+        });
+        this.transaction.end_data(function () {
+            self.transaction.message_stream.get_data(function (body) {
+                test.ok(/banner$/.test(body.trim()), "banner applied");
+                test.done();
+            });
+        });
+    },
 };

--- a/transaction.js
+++ b/transaction.js
@@ -17,6 +17,7 @@ function Transaction() {
     this.rcpt_to = [];
     this.header_lines = [];
     this.data_lines = [];
+    this.attachment_start_hooks = [];
     this.banner = null;
     this.body_filters = [];
     this.data_bytes = 0;
@@ -52,6 +53,9 @@ Transaction.prototype.ensure_body = function() {
     }
 
     this.body = new body.Body(this.header);
+    this.attachment_start_hooks.forEach(function (h) {
+        self.body.on('attachment_start', h);
+    });
     if (this.banner) {
         this.body.set_banner(this.banner);
     }
@@ -157,8 +161,7 @@ Transaction.prototype.remove_header = function (key) {
 
 Transaction.prototype.attachment_hooks = function (start, data, end) {
     this.parse_body = 1;
-    this.ensure_body();
-    this.body.on('attachment_start', start);
+    this.attachment_start_hooks.push(start);
 };
 
 Transaction.prototype.set_banner = function (text, html) {


### PR DESCRIPTION
Previously, if you called Transaction.attachment_hooks before Transaction.set_banner or .add_body_filter, your banner or filter wouldn't be applied because the body had already been created inside attachment_hooks.  This delays creating the body until it's actually going to be used, so all of these methods can be called in any order and still take effect.

I also snuck in a test for my last pull request (#739), which added Transaction.add_body_filter but no test on it.