### PR TITLE
Prevent duplication of multi-part preamble text

### DIFF
--- a/mailbody.js
+++ b/mailbody.js
@@ -330,7 +330,6 @@ Body.prototype.parse_multipart_preamble = function (line) {
             return line;
         }
     }
-    this.body_text_encoded += line;
     return line;
 }
 


### PR DESCRIPTION
Currently, if you add Body filters (e.g. with Transaction.add_body_filter or indirectly with .set_banner), messages that contain a MIME multi-part preamble (often "This is a multi-part message in MIME format.") will be enqueued with that preamble repeated at the very end of the message, after the terminating boundary line.  This adds a test to catch the error and fixes it by not capturing the body text for multi-part containers.  It doesn't seem useful to capture that text anyway--it's not a text part for one, and we already don't capture the "text" of attachments.

The reason this fixes the issue is that when Body.parse_end is called, the body text for each body part is added to the returned "line" before filters are applied.  With no body text for containers, there's nothing to erroneously add to the returned line.  In (I think) every other case, we don't emit the body text until after filters are applied, so there's no duplication.

As far as I can tell, this duplication might actually be harmless (I learned from reading RFC 2046 that preambles *and* "epilogues" are valid), but Haraka shouldn't be modifying messages that way when it enqueues them.