### PR TITLE
only replace line ending if not \r\n

### DIFF
--- a/outbound.js
+++ b/outbound.js
@@ -382,7 +382,7 @@ exports.send_email = function () {
     var re = /^([^\n]*\n?)/;
     while (match = re.exec(contents)) {
         var line = match[1];
-        line = line.replace(/\n?$/, '\r\n'); // make sure it ends in \r\n
+        line = line.replace(/\r?\n?$/, '\r\n'); // make sure it ends in \r\n
         transaction.add_data(new Buffer(line));
         contents = contents.substr(match[1].length);
         if (contents.length === 0) {

--- a/tests/outbound.js
+++ b/tests/outbound.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var lines = [
+    'From: John Johnson <john@example.com>',
+    'To: Jane Johnson <jane@example.com>',
+    "Subject: What's for dinner?",
+    '',
+    "I'm hungry.",
+    '',
+];
+
+exports.outbound = {
+    // setUp : _set_up,
+    // tearDown : _tear_down,
+    'converts \\n and \\r\\n line endings to \\r\\n' : function (test) {
+        test.expect(2);
+
+        ['\n', '\r\n'].forEach(function (ending) {
+            var contents = lines.join(ending);
+            var result = '';
+
+            // Set data_lines to lines in contents
+            var match;
+            var re = /^([^\n]*\n?)/;
+            while (match = re.exec(contents)) {
+                var line = match[1];
+                line = line.replace(/\r?\n?$/, '\r\n'); // assure \r\n ending
+                // transaction.add_data(new Buffer(line));
+                result += line;
+                contents = contents.substr(match[1].length);
+                if (contents.length === 0) {
+                    break;
+                }
+            }
+
+            test.deepEqual(lines.join('\r\n'), result);
+        });
+        test.done();
+    }
+};
+


### PR DESCRIPTION
this is an alternative to PR #767 

And it includes a handy little test that validates that it does what it's supposed to. Thanks to @chazomaticus for suggesting this regexp.

````
$ ./run_tests tests/outbound.js 
Running tests:  [ 'tests/outbound.js' ]

outbound.js
✔ outbound - converts \n and \r\n line endings to \r\n

OK: 2 assertions (3ms)
````