### PR TITLE
fix adding timestamps to log messages

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -147,7 +147,13 @@ logger._init_timestamps = function () {
     });
     
     if (_timestamps) {
-        console.log = original_console_log.bind(console, new Date().toISOString());
+        console.log = function() {
+            var new_arguments = [new Date().toISOString()];
+            for (var key in arguments) {
+                new_arguments.push(arguments[key]);
+            }
+            original_console_log.apply(console, new_arguments);
+        }
     }
     else {
         console.log = original_console_log;


### PR DESCRIPTION
The current method of adding a log timestamp results in the startup time of
Haraka being added to every log message, which isn't ideal. Use a proxy function
which uses a new Date for every log message written to the console.