### PR TITLE
Added environment definable plugin directories using semi-colon ';' delim

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -4,6 +4,7 @@
 var logger      = require('./logger');
 var config      = require('./config');
 var constants   = require('./constants');
+var os          = require('os');
 var path        = require('path');
 var vm          = require('vm');
 var fs          = require('fs');
@@ -13,9 +14,11 @@ var states      = require('./connection').states;
 
 var plugin_paths = [path.join(__dirname, './plugins')];
 if (process.env.HARAKA) { plugin_paths.unshift(path.join(process.env.HARAKA, 'plugins')); }
-// Allow environment customized path to plugins in addition to defaults. Multiple paths separated by semi-colon ';'
+// Allow environment customized path to plugins in addition to defaults.
+// Multiple paths separated by (semi-)colon ':|;' depending on environment.
 if (process.env.HARAKA_PLUGIN_PATH) {
-    var paths = process.env.HARAKA_PLUGIN_PATH.split(';').map(function(p) {
+    var separator = os.type().indexOf('Windows') >= 0 ? ';' : ':';
+    var paths = process.env.HARAKA_PLUGIN_PATH.split(separator).map(function(p) {
         var pNorm = path.normalize(p);
         logger.logdebug('Adding plugin path: ' + pNorm);
         plugin_paths.unshift(pNorm);

--- a/plugins.js
+++ b/plugins.js
@@ -13,6 +13,14 @@ var states      = require('./connection').states;
 
 var plugin_paths = [path.join(__dirname, './plugins')];
 if (process.env.HARAKA) { plugin_paths.unshift(path.join(process.env.HARAKA, 'plugins')); }
+// Allow environment customized path to plugins in addition to defaults. Multiple paths separated by semi-colon ';'
+if (process.env.HARAKA_PLUGIN_PATH) {
+    var paths = process.env.HARAKA_PLUGIN_PATH.split(';').map(function(p) {
+        var pNorm = path.normalize(p);
+        logger.logdebug('Adding plugin path: ' + pNorm);
+        plugin_paths.unshift(pNorm);
+    });
+}
 
 function Plugin(name) {
     this.name = name;


### PR DESCRIPTION
Helps plugin developers organize their development/testing environment how they'd like it set up. Provides power for hosted platforms as well to install as NPM but put plugin directory somewhere else.