### PR TITLE
rename is_rfc1918 -> is_private_ip, add IPv6 capability

### DIFF
--- a/net_utils.js
+++ b/net_utils.js
@@ -191,7 +191,7 @@ exports.is_ip_in_str = function(ip, str) {
     return false;
 };
 
-exports.is_rfc1918 = function (ip) {
+exports.is_private_ip = function (ip) {
     if (net.isIPv4(ip)) {
         return re_private_ipv4.test(ip);
     }
@@ -200,6 +200,9 @@ exports.is_rfc1918 = function (ip) {
     }
     return false;
 };
+
+// backwards compatibility for non-public modules. Sunset: Haraka 3.0
+exports.is_rfc1918 = exports.is_private_ip;
 
 exports.is_ipv4_literal = function (host) {
     return /^\[(\d{1,3}\.){3}\d{1,3}\]$/.test(host) ? true : false;

--- a/net_utils.js
+++ b/net_utils.js
@@ -7,6 +7,7 @@ var punycode = require('punycode');
 
 // Regexp to match private IPv4 ranges
 var re_private_ipv4 = /^(?:10|127|169\.254|172\.(?:1[6-9]|2[0-9]|3[01])|192\.168)\..*/;
+var re_private_ipv6 = /^(?:::1|(?:0{1,4}:){7}0{0,3}1)$/;
 
 var public_suffix_list = {};
 load_public_suffix_list();
@@ -191,7 +192,13 @@ exports.is_ip_in_str = function(ip, str) {
 };
 
 exports.is_rfc1918 = function (ip) {
-    return (net.isIPv4(ip) && re_private_ipv4.test(ip));
+    if (net.isIPv4(ip)) {
+        return re_private_ipv4.test(ip);
+    }
+    else if (net.isIPv6(ip)) {
+        return re_private_ipv6.test(ip);
+    }
+    return false;
 };
 
 exports.is_ipv4_literal = function (host) {

--- a/plugins/auth/flat_file.js
+++ b/plugins/auth/flat_file.js
@@ -17,7 +17,7 @@ exports.load_flat_ini = function () {
 exports.hook_capabilities = function (next, connection) {
     var plugin = this;
     // don't allow AUTH unless private IP or encrypted
-    if (!net_utils.is_rfc1918(connection.remote_ip) && !connection.using_tls) {
+    if (!net_utils.is_private_ip(connection.remote_ip) && !connection.using_tls) {
         connection.logdebug(plugin,
                 "Auth disabled for insecure public connection");
         return next();

--- a/plugins/connect.asn.js
+++ b/plugins/connect.asn.js
@@ -107,7 +107,7 @@ exports.get_dns_results = function (zone, ip, done) {
 exports.lookup_asn = function (next, connection) {
     var plugin = this;
     var ip = connection.remote_ip;
-    if (net_utils.is_rfc1918(ip)) return next();
+    if (net_utils.is_private_ip(ip)) return next();
 
     function provIter (zone, cb) {
 

--- a/plugins/connect.fcrdns.js
+++ b/plugins/connect.fcrdns.js
@@ -25,7 +25,7 @@ exports.load_fcrdns_ini = function () {
 exports.hook_lookup_rdns = function (next, connection) {
     var plugin = this;
     var rip = connection.remote_ip;
-    if (net_utils.is_rfc1918(rip)) {
+    if (net_utils.is_private_ip(rip)) {
         connection.results.add(plugin, {skip: "private_ip"});
         return next();
     }
@@ -80,7 +80,7 @@ exports.hook_lookup_rdns = function (next, connection) {
             if (!net_utils.get_organizational_domain(ptr_domain)) {
                 connection.results.add(plugin, {fail: 'valid_tld(' + ptr_domain +')'});
                 if (!plugin.cfg.reject.invalid_tld) continue;
-                if (net_utils.is_rfc1918(rip)) continue;
+                if (net_utils.is_private_ip(rip)) continue;
                 return do_next(DENY, 'client [' + rip +
                         '] rejected; invalid TLD in rDNS (' + ptr_domain + ')');
             }

--- a/plugins/connect.geoip.js
+++ b/plugins/connect.geoip.js
@@ -188,7 +188,7 @@ exports.get_geoip = function (ip) {
     var plugin = this;
     if (!ip) return;
     if (!net.isIPv4(ip) && !net.isIPv6(ip)) return;
-    if (net_utils.is_rfc1918(ip)) return;
+    if (net_utils.is_private_ip(ip)) return;
 
     var res = plugin.get_geoip_maxmind(ip);
     if (!res) {
@@ -348,7 +348,7 @@ exports.received_headers = function (connection) {
     for (var i=0; i < received.length; i++) {
         var match = /\[(\d+\.\d+\.\d+\.\d+)\]/.exec(received[i]);
         if (!match) continue;
-        if (net_utils.is_rfc1918(match[1])) continue;  // exclude private IP
+        if (net_utils.is_private_ip(match[1])) continue;  // exclude private IP
 
         var gi = plugin.get_geoip(match[1]);
         var country = gi.countryCode || gi.code || 'UNKNOWN';

--- a/plugins/data.uribl.js
+++ b/plugins/data.uribl.js
@@ -118,7 +118,7 @@ exports.do_lookups = function (connection, next, hosts, type) {
                     continue;
                 }
                 // Skip any private IPs
-                if (net_utils.is_rfc1918(host)) {
+                if (net_utils.is_private_ip(host)) {
                     results.add(plugin, {skip: 'private IP' });
                     continue;
                 }

--- a/plugins/dnsbl.js
+++ b/plugins/dnsbl.js
@@ -75,7 +75,7 @@ exports.should_skip = function (connection) {
     if (!connection) { return true; }
     var rip = connection.remote_ip;
 
-    if (net_utils.is_rfc1918(rip)) {
+    if (net_utils.is_private_ip(rip)) {
          connection.logdebug(plugin, 'skipping private IP: ' + rip);
          return true;
     }

--- a/plugins/helo.checks.js
+++ b/plugins/helo.checks.js
@@ -121,7 +121,7 @@ exports.should_skip = function (connection, test_name) {
         return true;
     }
 
-    if (plugin.cfg.skip.private_ip && net_utils.is_rfc1918(connection.remote_ip)) {
+    if (plugin.cfg.skip.private_ip && net_utils.is_private_ip(connection.remote_ip)) {
         connection.results.add(plugin, {skip: test_name + '(private)'});
         return true;
     }
@@ -346,7 +346,7 @@ exports.literal_mismatch = function (next, connection, helo) {
 
     var lmm_mode = parseInt(plugin.cfg.check.literal_mismatch, 10);
     var helo_ip = literal[1];
-    if (lmm_mode > 2 && net_utils.is_rfc1918(helo_ip)) {
+    if (lmm_mode > 2 && net_utils.is_private_ip(helo_ip)) {
         connection.results.add(plugin, {pass: 'literal_mismatch(private)'});
         return next();
     }

--- a/plugins/messagesniffer.js
+++ b/plugins/messagesniffer.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs');
 var net = require('net');
-var is_rfc1918 = require('./net_utils').is_rfc1918;
+var net_utils = require('./net_utils');
 var plugin = exports;
 
 // Defaults
@@ -18,7 +18,7 @@ exports.hook_connect = function (next, connection) {
     var cfg = this.config.get('messagesniffer.ini');
 
     // Skip any private IP ranges
-    if (is_rfc1918(connection.remote_ip)) return next();
+    if (net_utils.is_private_ip(connection.remote_ip)) return next();
 
     // Retrieve GBUdb information for the connecting IP
     SNFClient("<snf><xci><gbudb><test ip='" + connection.remote_ip + "'/></gbudb></xci></snf>", function (err, result) {

--- a/plugins/spf.js
+++ b/plugins/spf.js
@@ -69,7 +69,7 @@ exports.hook_helo = exports.hook_ehlo = function (next, connection, helo) {
     var plugin = this;
 
     // Bypass private IPs
-    if (net_utils.is_rfc1918(connection.remote_ip)) { return next(); }
+    if (net_utils.is_private_ip(connection.remote_ip)) { return next(); }
 
     // RFC 4408, 2.1: "SPF clients must be prepared for the "HELO"
     //           identity to be malformed or an IP address literal.
@@ -111,7 +111,7 @@ exports.hook_mail = function (next, connection, params) {
     var plugin = this;
 
     // For inbound message from a private IP, skip MAIL FROM check
-    if (!connection.relaying && net_utils.is_rfc1918(connection.remote_ip)) return next();
+    if (!connection.relaying && net_utils.is_private_ip(connection.remote_ip)) return next();
 
     var txn = connection.transaction;
     if (!txn) return next();
@@ -179,7 +179,7 @@ exports.hook_mail = function (next, connection, params) {
     }
 
     // outbound (relaying), context=myself, private IP
-    if (net_utils.is_rfc1918(connection.remote_ip)) return next();
+    if (net_utils.is_private_ip(connection.remote_ip)) return next();
 
     // outbound (relaying), context=myself
     net_utils.get_public_ip(function(e, sender_ip) {

--- a/tests/net_utils.js
+++ b/tests/net_utils.js
@@ -374,49 +374,49 @@ exports.is_ipv4_literal = {
     },
 };
 
-function _is_rfc1918(test, ip, expected) {
+function _is_private_ip(test, ip, expected) {
     test.expect(1);
-    test.equals(expected, net_utils.is_rfc1918(ip));
+    test.equals(expected, net_utils.is_private_ip(ip));
     test.done();
 };
 
 
-exports.is_rfc1918 = {
+exports.is_private_ip = {
     '127.0.0.1': function (test) {
-        _is_rfc1918(test, '127.0.0.1', true);
+        _is_private_ip(test, '127.0.0.1', true);
     },
     '10.255.31.23': function (test) {
-        _is_rfc1918(test, '10.255.31.23', true);
+        _is_private_ip(test, '10.255.31.23', true);
     },
     '172.16.255.254': function (test) {
-        _is_rfc1918(test, '172.16.255.254', true);
+        _is_private_ip(test, '172.16.255.254', true);
     },
     '192.168.123.123': function (test) {
-        _is_rfc1918(test, '192.168.123.123', true);
+        _is_private_ip(test, '192.168.123.123', true);
     },
     '169.254.23.54 (APIPA)': function (test) {
-        _is_rfc1918(test, '169.254.23.54', true);
+        _is_private_ip(test, '169.254.23.54', true);
     },
     '::1': function (test) {
-        _is_rfc1918(test, '::1', true);
+        _is_private_ip(test, '::1', true);
     },
     '0:0:0:0:0:0:0:1': function (test) {
-        _is_rfc1918(test, '0:0:0:0:0:0:0:1', true);
+        _is_private_ip(test, '0:0:0:0:0:0:0:1', true);
     },
     '0000:0000:0000:0000:0000:0000:0000:0001': function (test) {
-        _is_rfc1918(test, '0000:0000:0000:0000:0000:0000:0000:0001', true);
+        _is_private_ip(test, '0000:0000:0000:0000:0000:0000:0000:0001', true);
     },
     '123.123.123.123': function (test) {
-        _is_rfc1918(test, '123.123.123.123', false);
+        _is_private_ip(test, '123.123.123.123', false);
     },
     'dead::beef': function (test) {
-        _is_rfc1918(test, 'dead::beef', false);
+        _is_private_ip(test, 'dead::beef', false);
     },
     '192.168.1 (missing octet)': function (test) {
-        _is_rfc1918(test, '192.168.1', false);
+        _is_private_ip(test, '192.168.1', false);
     },
     '239.0.0.1 (multicast; not currently considered rfc1918)': function (test) {
-        _is_rfc1918(test, '239.0.0.1', false);
+        _is_private_ip(test, '239.0.0.1', false);
     },
 };
 

--- a/tests/net_utils.js
+++ b/tests/net_utils.js
@@ -374,6 +374,53 @@ exports.is_ipv4_literal = {
     },
 };
 
+function _is_rfc1918(test, ip, expected) {
+    test.expect(1);
+    test.equals(expected, net_utils.is_rfc1918(ip));
+    test.done();
+};
+
+
+exports.is_rfc1918 = {
+    '127.0.0.1': function (test) {
+        _is_rfc1918(test, '127.0.0.1', true);
+    },
+    '10.255.31.23': function (test) {
+        _is_rfc1918(test, '10.255.31.23', true);
+    },
+    '172.16.255.254': function (test) {
+        _is_rfc1918(test, '172.16.255.254', true);
+    },
+    '192.168.123.123': function (test) {
+        _is_rfc1918(test, '192.168.123.123', true);
+    },
+    '169.254.23.54 (APIPA)': function (test) {
+        _is_rfc1918(test, '169.254.23.54', true);
+    },
+    '::1': function (test) {
+        _is_rfc1918(test, '::1', true);
+    },
+    '0:0:0:0:0:0:0:1': function (test) {
+        _is_rfc1918(test, '0:0:0:0:0:0:0:1', true);
+    },
+    '0000:0000:0000:0000:0000:0000:0000:0001': function (test) {
+        _is_rfc1918(test, '0000:0000:0000:0000:0000:0000:0000:0001', true);
+    },
+    '123.123.123.123': function (test) {
+        _is_rfc1918(test, '123.123.123.123', false);
+    },
+    'dead::beef': function (test) {
+        _is_rfc1918(test, 'dead::beef', false);
+    },
+    '192.168.1 (missing octet)': function (test) {
+        _is_rfc1918(test, '192.168.1', false);
+    },
+    '239.0.0.1 (multicast; not currently considered rfc1918)': function (test) {
+        _is_rfc1918(test, '239.0.0.1', false);
+    },
+};
+
+
 exports.get_public_ip = {
     setUp: function (callback) {
         this.net_utils = require("../net_utils");


### PR DESCRIPTION
this is @smfreegard 's PR #852, squashed, rebased, and with an extra commit that renames is_rfc1918 to ip_private_ip. 

Closes #852
Closes #850 