### PR TITLE
net_utils: refactoring for IPv6 compatibility, simplicity and maintainability

### DIFF
--- a/docs/Net_Utils.md
+++ b/docs/Net_Utils.md
@@ -3,8 +3,8 @@ Net\_Utils
 
 This module provides network utility functions.
 
-Files
------
+## Files
+
 
 Portions of this module depend on the following files to function:
 
@@ -41,8 +41,8 @@ Portions of this module depend on the following files to function:
   http://rss.uribl.com/hosters/hosters.txt
 
 
-Usage
------
+## Usage
+
 
     var net_utils = require('./net_utils');
 
@@ -60,6 +60,8 @@ Usage
     if (net_utils.is_public_suffix('wikipedia.org')) {
         // false
     }
+
+### get_organizational_domain
 
     // reduces a hostname to an Organizational Domain
     // The O.D. is the portion of a domain name immediately delegated by a registrar
@@ -79,6 +81,7 @@ Usage
         // eg: root@mail.example.com would match sysadmin@example.com
     }
 
+### split_hostname
 
     // Split FQDN to host and domain
     var split = net_utils.split_hostname('host.sub1.sub2.domain.com');
@@ -92,14 +95,50 @@ Usage
         // true
     }
 
+### ip_to_long
+
     // Convert IPv4 to long
     var long = net_utils.ip_to_long('11.22.33.44');  // 185999660
+
+### long_to_ip
 
     // Convert long to IPv4
     var ip = net_utils.long_to_ip(185999660);  // 11.22.33.44
 
+### dec_to_hex
+
     // Convert decimal to hex
     var hex = net_utils.dec_to_hex(20111104);  // 132df00
 
+### hex_to_dec
+
     // Convert hex to decimal
     var dec = net_utils.hex_to_dec('132df00');  // 20111104
+
+### is_local_ipv4
+
+    // Is IPv4 address on a local network?
+    net_utils.is_local_ipv4('127.0.0.200');   // true (localhost)
+    net_utils.is_local_ipv4('169.254.0.0');   // true (link local)
+    net_utils.is_local_ipv4('226.0.0.1');     // false
+
+### is_private_ipv4
+
+    // Is IPv4 address in RFC 1918 reserved private address space?
+    net_utils.is_private_ipv4('10.0.0.0');       // true
+    net_utils.is_private_ipv4('192.168.0.0');    // true
+    net_utils.is_private_ipv4('172.16.0.0');     // true
+
+### is_local_ipv6
+
+    // Is IPv6 addr on local network?
+    net_utils.is_local_ipv6('::1');           // true (localhost)
+    net_utils.is_local_ipv6('fe80::')         // true (link local)
+    net_utils.is_local_ipv6('fc00::')         // true (unique local)
+    net_utils.is_local_ipv6('fd00::')         // true (unique local)
+
+### is_private_ip
+
+    // determines if an IPv4 or IPv6 address is on a "private" network
+    // For IPv4, returns true if is_private_ipv4 or is_local_ipv4 are true
+    // For IPv6, returns true if is_local_ipv6 is true

--- a/plugins/auth/flat_file.js
+++ b/plugins/auth/flat_file.js
@@ -17,7 +17,7 @@ exports.load_flat_ini = function () {
 exports.hook_capabilities = function (next, connection) {
     var plugin = this;
     // don't allow AUTH unless private IP or encrypted
-    if (!net_utils.is_rfc1918(connection.remote_ip) && !connection.using_tls) {
+    if (!net_utils.is_private_ip(connection.remote_ip) && !connection.using_tls) {
         connection.logdebug(plugin,
                 "Auth disabled for insecure public connection");
         return next();

--- a/plugins/connect.asn.js
+++ b/plugins/connect.asn.js
@@ -107,7 +107,7 @@ exports.get_dns_results = function (zone, ip, done) {
 exports.lookup_asn = function (next, connection) {
     var plugin = this;
     var ip = connection.remote_ip;
-    if (net_utils.is_rfc1918(ip)) return next();
+    if (net_utils.is_private_ip(ip)) return next();
 
     function provIter (zone, cb) {
 

--- a/plugins/connect.fcrdns.js
+++ b/plugins/connect.fcrdns.js
@@ -25,7 +25,7 @@ exports.load_fcrdns_ini = function () {
 exports.hook_lookup_rdns = function (next, connection) {
     var plugin = this;
     var rip = connection.remote_ip;
-    if (net_utils.is_rfc1918(rip)) {
+    if (net_utils.is_private_ip(rip)) {
         connection.results.add(plugin, {skip: "private_ip"});
         return next();
     }
@@ -80,7 +80,7 @@ exports.hook_lookup_rdns = function (next, connection) {
             if (!net_utils.get_organizational_domain(ptr_domain)) {
                 connection.results.add(plugin, {fail: 'valid_tld(' + ptr_domain +')'});
                 if (!plugin.cfg.reject.invalid_tld) continue;
-                if (net_utils.is_rfc1918(rip)) continue;
+                if (net_utils.is_private_ip(rip)) continue;
                 return do_next(DENY, 'client [' + rip +
                         '] rejected; invalid TLD in rDNS (' + ptr_domain + ')');
             }

--- a/plugins/connect.geoip.js
+++ b/plugins/connect.geoip.js
@@ -188,7 +188,7 @@ exports.get_geoip = function (ip) {
     var plugin = this;
     if (!ip) return;
     if (!net.isIPv4(ip) && !net.isIPv6(ip)) return;
-    if (net_utils.is_rfc1918(ip)) return;
+    if (net_utils.is_private_ip(ip)) return;
 
     var res = plugin.get_geoip_maxmind(ip);
     if (!res) {
@@ -348,7 +348,7 @@ exports.received_headers = function (connection) {
     for (var i=0; i < received.length; i++) {
         var match = /\[(\d+\.\d+\.\d+\.\d+)\]/.exec(received[i]);
         if (!match) continue;
-        if (net_utils.is_rfc1918(match[1])) continue;  // exclude private IP
+        if (net_utils.is_private_ip(match[1])) continue;  // exclude private IP
 
         var gi = plugin.get_geoip(match[1]);
         var country = gi.countryCode || gi.code || 'UNKNOWN';

--- a/plugins/data.uribl.js
+++ b/plugins/data.uribl.js
@@ -118,7 +118,7 @@ exports.do_lookups = function (connection, next, hosts, type) {
                     continue;
                 }
                 // Skip any private IPs
-                if (net_utils.is_rfc1918(host)) {
+                if (net_utils.is_private_ip(host)) {
                     results.add(plugin, {skip: 'private IP' });
                     continue;
                 }

--- a/plugins/dnsbl.js
+++ b/plugins/dnsbl.js
@@ -75,7 +75,7 @@ exports.should_skip = function (connection) {
     if (!connection) { return true; }
     var rip = connection.remote_ip;
 
-    if (net_utils.is_rfc1918(rip)) {
+    if (net_utils.is_private_ip(rip)) {
          connection.logdebug(plugin, 'skipping private IP: ' + rip);
          return true;
     }

--- a/plugins/helo.checks.js
+++ b/plugins/helo.checks.js
@@ -121,7 +121,7 @@ exports.should_skip = function (connection, test_name) {
         return true;
     }
 
-    if (plugin.cfg.skip.private_ip && net_utils.is_rfc1918(connection.remote_ip)) {
+    if (plugin.cfg.skip.private_ip && net_utils.is_private_ip(connection.remote_ip)) {
         connection.results.add(plugin, {skip: test_name + '(private)'});
         return true;
     }
@@ -346,7 +346,7 @@ exports.literal_mismatch = function (next, connection, helo) {
 
     var lmm_mode = parseInt(plugin.cfg.check.literal_mismatch, 10);
     var helo_ip = literal[1];
-    if (lmm_mode > 2 && net_utils.is_rfc1918(helo_ip)) {
+    if (lmm_mode > 2 && net_utils.is_private_ip(helo_ip)) {
         connection.results.add(plugin, {pass: 'literal_mismatch(private)'});
         return next();
     }

--- a/plugins/messagesniffer.js
+++ b/plugins/messagesniffer.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs');
 var net = require('net');
-var is_rfc1918 = require('./net_utils').is_rfc1918;
+var net_utils = require('./net_utils');
 var plugin = exports;
 
 // Defaults
@@ -18,7 +18,7 @@ exports.hook_connect = function (next, connection) {
     var cfg = this.config.get('messagesniffer.ini');
 
     // Skip any private IP ranges
-    if (is_rfc1918(connection.remote_ip)) return next();
+    if (net_utils.is_private_ip(connection.remote_ip)) return next();
 
     // Retrieve GBUdb information for the connecting IP
     SNFClient("<snf><xci><gbudb><test ip='" + connection.remote_ip + "'/></gbudb></xci></snf>", function (err, result) {

--- a/plugins/spf.js
+++ b/plugins/spf.js
@@ -69,7 +69,7 @@ exports.hook_helo = exports.hook_ehlo = function (next, connection, helo) {
     var plugin = this;
 
     // Bypass private IPs
-    if (net_utils.is_rfc1918(connection.remote_ip)) { return next(); }
+    if (net_utils.is_private_ip(connection.remote_ip)) { return next(); }
 
     // RFC 4408, 2.1: "SPF clients must be prepared for the "HELO"
     //           identity to be malformed or an IP address literal.
@@ -111,7 +111,7 @@ exports.hook_mail = function (next, connection, params) {
     var plugin = this;
 
     // For inbound message from a private IP, skip MAIL FROM check
-    if (!connection.relaying && net_utils.is_rfc1918(connection.remote_ip)) return next();
+    if (!connection.relaying && net_utils.is_private_ip(connection.remote_ip)) return next();
 
     var txn = connection.transaction;
     if (!txn) return next();
@@ -179,7 +179,7 @@ exports.hook_mail = function (next, connection, params) {
     }
 
     // outbound (relaying), context=myself, private IP
-    if (net_utils.is_rfc1918(connection.remote_ip)) return next();
+    if (net_utils.is_private_ip(connection.remote_ip)) return next();
 
     // outbound (relaying), context=myself
     net_utils.get_public_ip(function(e, sender_ip) {


### PR DESCRIPTION
* rename net_utils.is_rfc1918 -> is_private_ip
* closes #850
* added net_utils.is_local_ipv4, is_private_ipv4, & is_local_ipv6.
    * updated is_private_ip to use them
    * adds IPv6 link local to is_private_ip
    * adds additional test coverage
    * considerably easier to maintain than one regex for ipv4 and one for ipv6
    * no significant performance impact (0.05 second difference on 2 million iterations)
    * side note: using ?: in /regex/.test(str) seems to make no performance different (less than rounding error in testing).