### PR TITLE
log.syslog: try loading strong-fork-syslog

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "optionalDependencies": {
     "node-syslog"   : "~1.1.7",
+    "strong-fork-syslog" : "~1.2.3",
     "ldapjs"        : "~0.7.1",
     "vs-stun"       : "~0.0.7",
     "maxmind"       : "*",

--- a/plugins/log.syslog.js
+++ b/plugins/log.syslog.js
@@ -1,13 +1,19 @@
-// send logs to syslog
+'use strict';
+// log to syslog
 
 exports.register = function() {
     var plugin = this;
 
     try { plugin.Syslog = require('node-syslog'); }
     catch (e) {
-        plugin.logerror("unable to load node-syslog, plugin disabled\n" +
-                "try: npm install node-syslog" );
-        return;
+        plugin.logerror('failed to load node-syslog');
+
+        try { plugin.Syslog = require('strong-fork-syslog'); }
+        catch (e) {
+            plugin.logerror("couldn't load strong-fork-syslog either");
+            plugin.logerror('try: npm i node-syslog strong-fork-syslog' );
+            return;
+        }
     }
 
     var options   = 0;
@@ -138,6 +144,8 @@ exports.syslog = function (next, logger, log) {
         case 'DATA':
         case 'PROTOCOL':
         case 'DEBUG':
+            plugin.Syslog.log(plugin.Syslog.LOG_DEBUG, log.data);
+            break;
         default:
             plugin.Syslog.log(plugin.Syslog.LOG_DEBUG, log.data);
     }


### PR DESCRIPTION
which works under node 0.12.

strong-fork-syslog is a fork of schamana/node-syslog, [who is npm-AWOL](https://github.com/schamane/node-syslog/pull/33), so the **other** project maintainers who are responsiive have published under the fork name, until such a time as schamane either a) permits someone else to publish to npm or b) does it himself. (it's been many months and releases and neither has happened).