### PR TITLE
Fixed bug with reading of config file for smtp_forward plugin

### DIFF
--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -22,6 +22,8 @@ exports.register = function () {
 exports.get_config = function (connection) {
     var plugin = this;
 
+    plugin.cfg.main.auth = plugin.cfg.auth;
+
     if (!connection.transaction) return plugin.cfg.main;
     if (!connection.transaction.rcpt_to[0]) return plugin.cfg.main;
     var dom = connection.transaction.rcpt_to[0].host;


### PR DESCRIPTION
When reading the smtp_forward.ini configuration, the get_config method returns plugin.cfg.main, but in parsing the ini file, data under the [auth] header, existing under plugin.cfg.auth, not plugin.cfg.main.auth.

Added plugin.cfg.auth to plugin.cfg.main.auth so it can be used by the plugin.

Otherwise, the [auth] configuration are not found.