### PR TITLE
allow domains with underscore

### DIFF
--- a/address.js
+++ b/address.js
@@ -38,7 +38,7 @@ function Address (user, host) {
 exports.atom_expr = /[a-zA-Z0-9!#%&*+=?\^_`{|}~\$\x27\x2D\/]+/;
 exports.address_literal_expr =
   /(?:\[(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|IPv6:[0-9A-Fa-f:.]+)\])/;
-exports.subdomain_expr = /(?:[a-zA-Z0-9](?:[\-a-zA-Z0-9]*[a-zA-Z0-9])?)/;
+exports.subdomain_expr = /(?:[a-zA-Z0-9](?:[_\-a-zA-Z0-9]*[a-zA-Z0-9])?)/;
 exports.domain_expr = undefined; // so you can override this when loading and re-run compile_re()
 exports.qtext_expr = /[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]/;
 exports.text_expr  = /\\([\x01-\x09\x0B\x0C\x0E-\x7F])/;


### PR DESCRIPTION
fixes 'Invalid domain in address' error parsing domains which contain underscores.  Underscores in domain name do not break spec and are often used.