### PR TITLE
log connection info to Elasticsearch

### DIFF
--- a/config/log.elasticsearch.ini
+++ b/config/log.elasticsearch.ini
@@ -1,0 +1,71 @@
+
+; By default, connections without transactions are stored in a separate
+; connections index as they're typically high noise and low signal. To not
+; store them at all, set this to false.
+; Default: true
+;
+; log_connections=false
+
+
+; Elasticsearch servers
+[hosts]
+; syntax: hostname=key:value. All values are optional.
+; Default: 127.0.0.1   -->  http://127.0.0.1:9200
+127.0.0.1
+
+
+; Future (q3-q4 2015) host resolution mechanism, after Matt adds a `selector`
+; function as documented here:
+; https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html
+; will use the datacenter and weight to choose from N hosts in the same data
+; center. Failing that, try hosts in another DC, based on weight.
+;
+; [hosts]
+; es1.lax.example.com=protocol:http, port:9200, datacenter:lax, weight:10
+; es2.lax.example.com=protocol:http, port:9200, datacenter:lax, weight:20
+; es1.nyc.example.com=protocol:https, port:9201, datacenter:nyc, weight:50
+; es2.nyc.example.com=protocol:https, port:9201, datacenter:nyc, weight:60
+
+
+; don't store connection results from these hosts
+[ignore_hosts]
+;servedby.tnpi.net
+
+
+[index]
+; default ES index names are shown.
+; Transactions include all the connection
+; information and are "the good stuff." When a connection has transactions,
+; the connection is not saved separately. The distinction is that a connection
+; is stored when it has zero transactions. The connections index tends to
+; be mostly noise (monitoring, blocked connections, bruteforce auth attempts,
+; etc.) and for that reason, some choose not to store them at all.
+;
+;transaction=smtp-transaction
+;connection=smtp-connection
+
+
+; At the top level, each ES document has thre categories: connection, message,
+; and plugins. Those names can be customized here.
+[top_level_names]
+;connection=conn
+;plugin=p
+;message=msg
+
+
+; Properties of the connection to include in the ES connection document.
+; defaults are shown. These can be reported with another name by adding an ini
+; value
+[connection_properties]
+pipelining
+using_tls=tls
+relaying=relay
+totalbytes=bytes
+early_talker=early
+
+
+; Message headers to store (if present)
+[headers]
+From
+To
+Subject

--- a/docs/plugins/log.elasticsearch.md
+++ b/docs/plugins/log.elasticsearch.md
@@ -193,7 +193,7 @@ curl -XPUT localhost:9200/_template/haraka_results -d '
                         }
                     }
                 },
-                "msg" : {
+                "message" : {
                     "properties" : {
                         "bytes" : { "type": "double" },
                         "envelope": {
@@ -239,7 +239,7 @@ curl -XPUT localhost:9200/_template/haraka_results -d '
                         }
                     }
                 },
-                "conn" : {
+                "connection" : {
                     "properties" : {
                         "count" : {
                             "properties" : {

--- a/docs/plugins/log.elasticsearch.md
+++ b/docs/plugins/log.elasticsearch.md
@@ -1,0 +1,272 @@
+# log.elasticsearch
+
+# Logging
+
+Unless errors are encountered, no logs are emitted.
+
+# Errors
+
+The elasticsearch module has very robust error handling built in. If there's a
+connection issue, errors such as these will be emitted when Haraka starts
+up:
+
+* Elasticsearch cluster is down!
+* No Living connections
+
+However, ES will continue attempting to connect and when the ES server becomes
+available, logging will begin. If errors are encountered trying to save data
+to ES, they look like this:
+
+* No Living connections
+* Request Timeout after 30000ms
+
+They normally fix themselves when ES resumes working properly.
+
+# Configuration
+
+* host - an IP or hostname of the ES server to connect to
+
+    host=127.0.0.2
+
+* pluginObject
+
+By default, all plugin results are presented as `$plugin_name: { ... }`, at
+the top level. If you prefer that all plugin results be nested inside an
+object `$obj: { $plugin_name: { ...}`, set pluginObject to that object's key name
+
+    pluginObject=plugin
+
+
+* [ignore_hosts]
+
+A config file section for hosts whose results should not be stored in
+ES. HAproxy servers, Nagios, and other hosts who monitor Haraka can be listed
+here. The format for entries is host.name=true
+
+* [index]
+
+    transaction=smtp-transaction
+    connection=smtp-connection
+
+Transactions include all the connection information and are "the good stuff."
+When a connection has transactions, the connection is not saved separately.
+The distinction is that a connection is stored only when it has zero
+transactions. The connections index tends to be mostly noise (monitoring,
+blocked connections, bruteforce auth attempts, etc.). To collapse them into
+the same index, set the value for both identically.
+
+
+# Index map template
+
+Creating a map template will apply the template(s) to any future indexes that
+match the pattern/name in the template setting. This is how to manually apply
+an index map template:
+
+```json
+curl -XPUT localhost:9200/_template/haraka_results -d '
+{
+    "template" : "smtp-*",
+    "mappings" : {
+        "haraka" : {
+            "dynamic_templates" : [
+                { "fail_results" : {
+                        "match" : "fail",
+                        "mapping" : {
+                            "type" : "string", "index" : "not_analyzed"
+                        }
+                    }
+                },
+                { "pass_results" : {
+                        "match" : "pass",
+                        "mapping" : {
+                            "type" : "string", "index" : "not_analyzed"
+                        }
+                    }
+                },
+                { "skip_results" : {
+                        "match" : "skip",
+                        "mapping" : {
+                            "type" : "string", "index" : "not_analyzed"
+                        }
+                    }
+                },
+                { "msg_results" : {
+                        "match" : "msg",
+                        "mapping" : {
+                            "type" : "string", "index" : "not_analyzed"
+                        }
+                    }
+                },
+                { "err_results" : {
+                        "match" : "err",
+                        "mapping" : {
+                            "type" : "string", "index" : "not_analyzed"
+                        }
+                    }
+                },
+                { "ip_addrs" : {
+                        "match" : "ip",
+                        "mapping" : { "type" : "ip" }
+                    }
+                },
+                { "hostnames" : {
+                        "match" : "host",
+                        "mapping" : {
+                            "type" : "string", "index" : "not_analyzed"
+                        }
+                    }
+                }
+            ],
+            "properties" : {
+                "plugin" : {
+                    "properties" : {
+                        "asn" : {
+                            "properties" : {
+                                "org" : { "type" : "string", "index" : "not_analyzed" },
+                                "asn_good"        : { "type" : "double" },
+                                "asn_bad"         : { "type" : "double" },
+                                "asn_score"       : { "type" : "double" },
+                                "asn_connections" : { "type" : "double" }
+                            }
+                        },
+                        "geoip" : {
+                            "properties" : {
+                                "org"      : { "type" : "string", "index" : "not_analyzed" },
+                                "ll"       : { "type" : "geo_point" },
+                                "distance" : { "type" : "float" }
+                            }
+                        },
+                        "helo" : {
+                            "properties"   : {
+                                "ips"      : { "type" : "string", "index" : "not_analyzed" }
+                            }
+                        },
+                        "fcrdns" : {
+                            "properties"    : {
+                                "fcrdns"    : { "type" : "string", "index" : "not_analyzed" },
+                                "other_ips" : { "type" : "string", "index" : "not_analyzed" },
+                                "ptr_names" : { "type" : "string", "index" : "not_analyzed" }
+                            }
+                        },
+                        "p0f" : {
+                            "properties" : {
+                                "os_flavor" : { "type" : "string", "index" : "not_analyzed" }
+                            }
+                        },
+                        "rspamd" : {
+                            "properties"   : {
+                                "emails"   : { "type" : "string", "index" : "not_analyzed" },
+                                "urls"     : { "type" : "string", "index" : "not_analyzed" },
+                                "messages" : { "type" : "string", "index" : "not_analyzed" }
+                            }
+                        },
+                        "karma" : {
+                            "properties" : {
+                                "connect"   : { "type" : "double" },
+                                "score"     : { "type" : "double" },
+                                "good"      : { "type" : "double" },
+                                "bad"       : { "type" : "double" },
+                                "history"   : { "type" : "double" },
+                                "connections" : { "type" : "double" },
+                                "total_connects" : { "type" : "double" },
+                                "neighbors" : { "type" : "double" }
+                            }
+                        },
+                        "spamassassin" : {
+                            "properties" : {
+                                "headers": {
+                                    "properties" : {
+                                        "report" : { "type" : "string", "index" : "not_analyzed" },
+                                        "Status" : { "type" : "string", "index" : "not_analyzed" }
+                                    }
+                                },
+                                "line0" : { "type" : "string", "index" : "not_analyzed" },
+                                "reqd"  : { "type" : "double" },
+                                "score" : { "type" : "double" },
+                                "tests" : { "type" : "string", "index" : "not_analyzed" }
+                            }
+                        },
+                        "spf" : {
+                            "properties" : {
+                                "domain" : { "type" : "string", "index" : "not_analyzed" }
+                            }
+                        }
+                    }
+                },
+                "msg" : {
+                    "properties" : {
+                        "bytes" : { "type": "double" },
+                        "envelope": {
+                            "properties": {
+                                "sender" : { "type" : "string", "index" : "not_analyzed" },
+                                "recipient" : {
+                                    "properties"  : {
+                                        "action"  : { "type" : "string", "index" : "not_analyzed" },
+                                        "address" : { "type" : "string", "index" : "not_analyzed" }
+                                    }
+                                }
+                            }
+                        },
+                        "header": {
+                            "properties": {
+                                "from"         : { "type" : "string", "index" : "not_analyzed" },
+                                "to"           : { "type" : "string", "index" : "not_analyzed" },
+                                "subject"      : { "type" : "string", "index" : "not_analyzed" },
+                                "message-id"   : { "type" : "string", "index" : "not_analyzed" },
+                                "date"         : { "type" : "string", "index" : "not_analyzed" },
+                                "reply-to"     : { "type" : "string", "index" : "not_analyzed" },
+                                "resent-from"  : { "type" : "string", "index" : "not_analyzed" },
+                                "resent-header": { "type" : "string", "index" : "not_analyzed" },
+                                "sender"       : { "type" : "string", "index" : "not_analyzed" }
+                            }
+                        },
+                        "body" : {
+                            "properties" : {
+                                "attachment" : {
+                                    "properties": {
+                                        "bytes" : { "type" : "float" },
+                                        "ctype" : { "type" : "string" },
+                                        "file"  : { "type" : "string" },
+                                        "md5"   : { "type" : "string", "index": "not_analyzed" }
+                                    }
+                                }
+                            }
+                        },
+                        "queue" : {
+                            "properties" : {
+
+                            }
+                        }
+                    }
+                },
+                "conn" : {
+                    "properties" : {
+                        "count" : {
+                            "properties" : {
+                                "msg" : {
+                                    "properties" : {
+                                        "accept" : { "type": "integer" },
+                                        "reject" : { "type": "integer" },
+                                        "tempfail" : { "type": "integer" }
+                                    }
+                                },
+                                "rcpt" : {
+                                    "properties" : {
+                                        "accept" : { "type": "integer" },
+                                        "reject" : { "type": "integer" },
+                                        "tempfail" : { "type": "integer" }
+                                    }
+                                },
+                                "errors" : { "type": "integer" },
+                                "trans" : { "type": "integer" }
+                            }
+                        },
+                        "early" : { "type" : "boolean" }
+                    }
+                }
+            }
+        }
+    }
+}'
+
+```

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "maxmind": "*",
     "redis": "~0.10.1",
     "tmp": "~0.0.24",
-    "haraka-nosql": "*"
+    "haraka-nosql": "*",
+    "elasticsearch": "*"
   },
   "devDependencies": {
     "nodeunit"      : "https://github.com/godsflaw/nodeunit/archive/master.tar.gz",

--- a/plugins/log.elasticsearch.js
+++ b/plugins/log.elasticsearch.js
@@ -1,0 +1,526 @@
+'use strict';
+// log to Elasticsearch
+
+var utils = require('./utils');
+
+exports.register = function() {
+    var plugin = this;
+
+    try {
+        var elasticsearch = require('elasticsearch');
+    }
+    catch (err) {
+        plugin.logerror(err);
+        return;
+    }
+
+    plugin.load_es_ini();
+
+    plugin.es = new elasticsearch.Client({
+        hosts: plugin.cfg.es_hosts,
+        // sniffOnStart: true,     // discover the rest of the ES nodes
+        // sniffInterval: 300000,  // check every 5 min.
+        // sniffOnConnectionFault: true,
+        // log: 'trace',
+    });
+
+    plugin.es.ping({
+        // ping usually has a 100ms timeout
+        requestTimeout: 1000,
+
+        // undocumented params are appended to the query string
+        hello: "elasticsearch!"
+        }, function (error) {
+        if (error) {
+            // we don't bother error handling hear b/c the ES library does
+            // that for us.
+            plugin.logerror('cluster is down!');
+        }
+        else {
+            plugin.lognotice('connected');
+        }
+    });
+
+    plugin.register_hook('reset_transaction', 'log_transaction');
+    plugin.register_hook('disconnect',        'log_connection');
+};
+
+exports.load_es_ini = function () {
+    var plugin = this;
+
+    plugin.cfg = plugin.config.get('log.elasticsearch.ini', {
+        booleans: [
+            '+main.log_connections',
+        ]
+    },
+    function () {
+        plugin.load_es_ini();
+    });
+
+    plugin.get_es_hosts();
+
+    if (plugin.cfg.ignore_hosts) {
+        // convert bare entries (w/undef values) to true
+        Object.keys(plugin.cfg.ignore_hosts).forEach(function (key) {
+            if (plugin.cfg.ignore_hosts[key]) return;
+            plugin.cfg.ignore_hosts[key]=true;
+        });
+    }
+
+    plugin.cfg.headers = plugin.cfg.headers ?
+        Object.keys(plugin.cfg.headers)     :
+        ['From', 'To', 'Subject'];
+
+    plugin.cfg.conn_props = plugin.cfg.connection_properties ||
+        {   using_tls:undefined,
+            relaying:undefined,
+            totalbytes:undefined,
+            pipelining:undefined,
+            early_talker:undefined,
+        };
+};
+
+exports.get_es_hosts = function () {
+    var plugin = this;
+    if (!plugin.cfg.hosts) {   // no [hosts] config
+        plugin.cfg.es_hosts = []; // default: http://localhost:9200
+        return;
+    }
+
+    plugin.cfg.es_hosts = [];
+    Object.keys(plugin.cfg.hosts).forEach(function (host) {
+        if (!plugin.cfg.hosts[host]) {  // no options
+            plugin.cfg.es_hosts.push({host: host});
+            return;
+        }
+
+        var opts = { host: host };
+        plugin.cfg.hosts[host].trim().split(',').forEach(function(opt){
+            var o=opt.trim().split(':');
+            opts[o[0]] = o[1];
+        });
+
+        plugin.cfg.es_hosts.push(opts);
+    });
+};
+
+exports.log_transaction = function (next, connection) {
+    var plugin = this;
+
+    if (plugin.cfg.ignore_hosts) {
+        if (plugin.cfg.ignore_hosts[connection.remote_host]) return next();
+    }
+
+    var res = plugin.get_plugin_results(connection);
+    if (plugin.cfg.top_level_names && plugin.cfg.top_level_names.message) {
+        res[plugin.cfg.top_level_names.message] = res.message;
+        delete res.message;
+    }
+    res.timestamp = new Date().toISOString();
+
+    plugin.populate_conn_properties(connection, res);
+    plugin.es.create({
+        index: exports.getIndexName('transaction'),
+        type: 'haraka',
+        id: connection.transaction.uuid,
+        body: JSON.stringify(res),
+    }, function (error, response) {
+        if (error) {
+            connection.logerror(plugin, error.message);
+        }
+        // connection.loginfo(plugin, response);
+    });
+
+    // hook reset_transaction doesn't seem to wait for next(). If I
+    // wait until after I get a response back from ES, Haraka throws
+    // "Error: We are already running hooks!". So, record that we've sent
+    // to ES (so connection isn't saved) and hope for the best.
+    connection.notes.elasticsearch=connection.tran_count;
+    next();
+};
+
+exports.log_connection = function (next, connection) {
+    var plugin = this;
+    if (!plugin.cfg.main.log_connections) return next();
+
+    if (plugin.cfg.ignore_hosts) {
+        if (plugin.cfg.ignore_hosts[connection.remote_host]) return next();
+    }
+
+    if (connection.notes.elasticsearch &&
+        connection.notes.elasticsearch === connection.tran_count) {
+        connection.logdebug(plugin, 'skipping already logged txn');
+        return next();
+    }
+
+    var res = plugin.get_plugin_results(connection);
+    res.timestamp = new Date().toISOString();
+
+    plugin.populate_conn_properties(connection, res);
+
+    // connection.lognotice(plugin, JSON.stringify(res));
+    plugin.es.create({
+        index: exports.getIndexName('connection'),
+        type: 'haraka',
+        id: connection.uuid,
+        body: JSON.stringify(res),
+    }, function (error, response) {
+        if (error) {
+            connection.logerror(plugin, error.message);
+        }
+        // connection.loginfo(plugin, response);
+    });
+    next();
+};
+
+exports.objToArray = function (obj) {
+    var arr = [];
+    if (!obj || typeof obj !== 'object') return arr;
+    Object.keys(obj).forEach(function (k) {
+        arr.push({ k: k, v: obj[k] });
+    });
+    return arr;
+};
+
+exports.getIndexName = function (section) {
+    var plugin = this;
+
+    // Elasticsearch indexes named like: smtp-connection-2015-05-05
+    //                                   smtp-transaction-2015-05-05
+    var name = 'smtp-' + section;
+    if (plugin.cfg.index && plugin.cfg.index[section]) {
+        name = plugin.cfg.index[section];
+    }
+    var date = new Date();
+    var d = date.getDate();
+    var m = date.getMonth() + 1;
+    return name +
+           '-' + date.getFullYear() +
+           '-' + (m <= 9 ? '0' + m : m) +
+           '-' + (d <= 9 ? '0' + d : d);
+};
+
+exports.populate_conn_properties = function (conn, res) {
+    var plugin = this;
+    var conn_res = res;
+
+    if (plugin.cfg.top_level_names && plugin.cfg.top_level_names.connection) {
+        if (!res[plugin.cfg.top_level_names.connection]) {
+            res[plugin.cfg.top_level_names.connection] = {};
+        }
+        conn_res = res[plugin.cfg.top_level_names.connection];
+    }
+
+    conn_res.local = {
+        ip:   conn.local_ip,
+        port: conn.local_port,
+        host: plugin.cfg.hostname || require('os').hostname(),
+    };
+    conn_res.remote = {
+        ip:   conn.remote_ip,
+        host: conn.remote_host,
+        port: conn.remote_port,
+    };
+    conn_res.hello = {
+        host: conn.hello_host,
+        verb: conn.greeting,
+    };
+
+    if (!conn_res.auth) {
+        conn_res.auth = {};
+        if (plugin.cfg.top_level_names && plugin.cfg.top_level_names.plugin) {
+            var pia = plugin.cfg.top_level_names.plugin;
+            if (res[pia] && res[pia].auth) {
+                conn_res.auth = res[pia].auth;
+                delete res[pia].auth;
+            }
+        }
+        else {
+            if (res.auth) {
+                conn_res.auth = res.auth;
+                delete res.auth;
+            }
+        }
+    }
+
+    conn_res.count = {
+        errors: conn.errors,
+        msg: conn.msg_count,
+        rcpt: conn.rcpt_count,
+        trans: conn.tran_count,
+    };
+
+    Object.keys(plugin.cfg.conn_props).forEach(function (f) {
+        if (conn[f] === undefined) return;
+        if (conn[f] === 0) return;
+        if (plugin.cfg.conn_props[f]) {  // alias specified
+            conn_res[plugin.cfg.conn_props[f]] = conn[f];
+        }
+        else {
+            conn_res[f] = conn[f];
+        }
+    });
+
+    conn_res.duration = (Date.now() - conn.start_time)/1000;
+};
+
+exports.get_plugin_results = function (connection) {
+    var plugin = this;
+
+    var name;
+    // note that we make a copy of the result store, so subsequent changes
+    // here don't alter the original (by reference)
+    var pir = JSON.parse(JSON.stringify(connection.results.get_all()));
+    for (name in pir) { plugin.trim_plugin_names(pir, name); }
+    for (name in pir) {
+        plugin.prune_noisy(pir, name);
+        plugin.prune_empty(pir[name]);
+        plugin.prune_zero(pir, name);
+        plugin.prune_redundant_cxn(pir, name);
+    }
+
+    if (!connection.transaction) return plugin.nest_plugin_results(pir);
+
+    try {
+        var txr = JSON.parse(JSON.stringify(
+                    connection.transaction.results.get_all()));
+    }
+    catch (e) {
+        connection.transaction.results.add(plugin, {err: e.message });
+        return plugin.nest_plugin_results(pir);
+    }
+
+    for (name in txr) { plugin.trim_plugin_names(txr, name); }
+    for (name in txr) {
+        plugin.prune_noisy(txr, name);
+        plugin.prune_empty(txr[name]);
+        plugin.prune_zero(txr, name);
+        plugin.prune_redundant_txn(txr, name);
+    }
+
+    // merge transaction results into connection results
+    for (name in txr) {
+        if (!pir[name]) {
+            pir[name] = txr[name];
+        }
+        else {
+            utils.extend(pir[name], txr[name]);
+        }
+        delete txr[name];
+    }
+
+    plugin.populate_message(pir, connection);
+    return plugin.nest_plugin_results(pir);
+};
+
+exports.populate_message = function (pir, connection) {
+    var plugin = this;
+    pir.message = {
+        bytes: connection.transaction.data_bytes,
+        envelope: {
+            sender: '',
+            recipient: [],
+        },
+        header: {},
+        body: {
+            attachment: [],
+        },
+        queue: {},
+    };
+
+    if (pir.mail_from && pir.mail_from.address) {
+        pir.message.envelope.sender = pir.mail_from.address;
+        delete pir.mail_from.address;
+    }
+
+    if (pir.rcpt_to && pir.rcpt_to.recipient) {
+        pir.message.envelope.recipient = pir.rcpt_to.recipient;
+        delete pir.rcpt_to;
+    }
+
+    if (pir.attachment && pir.attachment.attach) {
+        pir.message.body.attachment = pir.attachment.attach;
+        delete pir.attachment;
+    }
+    if (pir.queue) {
+        pir.message.queue = pir.queue;
+        delete pir.queue;
+    }
+
+    plugin.cfg.headers.forEach(function (h) {
+        var r = connection.transaction.header.get_decoded(h);
+        if (!r) return;
+        pir.message.header[h] = r;
+    });
+};
+
+exports.nest_plugin_results = function (res) {
+    var plugin = this;
+    if (!plugin.cfg.top_level_names) return res;
+    if (!plugin.cfg.top_level_names.plugin) return res;
+
+    var new_res = {};
+    if (res.message) {
+        new_res.message = res.message;
+        delete res.message;
+    }
+    new_res[plugin.cfg.top_level_names.plugin] = res;
+    return new_res;
+};
+
+exports.trimPluginName = function (name) {
+
+    // for plugins named like: data.headers or connect.geoip, strip off the
+    // phase prefix and return `headers` or `geoip`
+    var parts = name.split('.');
+    if (parts.length < 2) return name;
+
+    switch (parts[0]) {
+        case 'helo':
+            return 'helo';
+        case 'connect':
+        case 'mail_from':
+        case 'rcpt_to':
+        case 'data':
+            return parts.slice(1).join('.');
+    }
+    return name;
+};
+
+exports.trim_plugin_names = function (res, name) {
+    var trimmed = exports.trimPluginName(name);
+    if (trimmed === name) return;
+
+    res[trimmed] = res[name];
+    delete res[name];
+    name = trimmed;
+};
+
+exports.prune_empty = function (pi) {
+
+    // remove undefined keys and empty strings, arrays, or objects
+    for (var e in pi) {
+        var val = pi[e];
+        if (val === undefined) {
+            delete pi[e];
+            continue;
+        }
+
+        if (typeof val === 'string') {
+            if (val === '') {
+               delete pi[e];
+               continue;
+            }
+        }
+        else if (Array.isArray(val)) {
+            if (val.length === 0) {
+                delete pi[e];
+                continue;
+            }
+        }
+        else if (typeof val === 'object') {
+            if (Object.keys(val).length === 0) {
+                delete pi[e];
+                continue;
+            }
+        }
+    }
+};
+
+exports.prune_noisy = function (res, pi) {
+    var plugin = this;
+
+    if (res[pi].human) { delete res[pi].human; }
+    if (res[pi].human_html) { delete res[pi].human_html; }
+    if (res[pi]._watch_saw) { delete res[pi]._watch_saw; }
+
+    switch (pi) {
+        case 'karma':
+            delete res.karma.todo;
+            delete res.karma.pass;
+            delete res.karma.skip;
+            break;
+        case 'access':
+            delete res.access.pass;
+            break;
+        case 'uribl':
+            delete res.uribl.skip;
+            delete res.uribl.pass;
+            break;
+        case 'dnsbl':
+            delete res.dnsbl.pass;
+            break;
+        case 'fcrdns':
+            var arr = plugin.objToArray(res.fcrdns.ptr_name_to_ip);
+            res.fcrdns.ptr_name_to_ip = arr;
+            break;
+        case 'max_unrecognized_commands':
+            res.unrecognized_commands =
+                res.max_unrecognized_commands.count;
+            delete res.max_unrecognized_commands;
+            break;
+        case 'spamassassin':
+            delete res.spamassassin.line0;
+            if (res.spamassassin.headers) {
+                delete res.spamassassin.headers.Tests;
+                delete res.spamassassin.headers.Level;
+            }
+    }
+};
+
+exports.prune_zero = function (res, name) {
+    for (var e in res[name]) {
+        if (res[name][e] !== 0) continue;
+        delete res[name][e];
+    }
+};
+
+exports.prune_redundant_cxn = function (res, name) {
+    switch (name) {
+        case 'helo':
+            if (res.helo && res.helo.helo_host) {
+                delete res.helo.helo_host;
+            }
+            break;
+        case 'p0f':
+            if (res.p0f && res.p0f.query) {
+                delete res.p0f.query;
+            }
+            break;
+    }
+};
+
+exports.prune_redundant_txn = function (res, name) {
+    switch (name) {
+        case 'spamassassin':
+            if (!res.spamassassin) break;
+            delete res.spamassassin.hits;
+            if (!res.spamassassin.headers) break;
+            if (!res.spamassassin.headers.Flag) break;
+            delete res.spamassassin.headers.Flag;
+            break;
+    }
+};
+
+exports.put_map_template = function () {
+    var plugin = this;
+    var template_name = 'smtp';
+    if (plugin.cfg.index && plugin.cfg.index.transaction) {
+        template_name = plugin.cfg.index.transaction;
+    }
+
+    /* jshint maxlen: 100 */
+    var body = {
+        "dynamic_templates" : [
+            // gone until docs for putTemplate are better
+        ]
+    };
+
+    // https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference-1-3.html#api-puttemplate-1-3
+    plugin.es.indices.putTemplate({
+        id: 'haraka_results',
+        template: template_name + '-*',
+        type: 'haraka',
+        body: body,
+    });
+};

--- a/tests/plugins/log.elasticsearch.js
+++ b/tests/plugins/log.elasticsearch.js
@@ -1,0 +1,178 @@
+'use strict';
+
+var stub             = require('../fixtures/stub');
+var Plugin           = require('../fixtures/stub_plugin');
+
+var Connection       = require('../fixtures/stub_connection');
+var config           = require('../../config');
+var ResultStore      = require('../../result_store');
+
+var _set_up = function (done) {
+
+    try {
+        this.plugin = new Plugin('log.elasticsearch');
+    }
+    catch (e) {
+        console.error('unable to load log.elasticsearch plugin');
+        return;
+    }
+
+    this.connection = Connection.createConnection();
+    this.connection.results = new ResultStore(this.plugin);
+    this.connection.notes = {};
+
+    this.plugin.config = config;
+    // console.log(this.plugin);
+
+    done();
+};
+
+exports.register = {
+    setUp : _set_up,
+    'has a register function' : function (test) {
+        test.expect(2);
+        test.isNotNull(this.plugin);
+        test.isFunction(this.plugin.register);
+        test.done();
+    },
+    /*
+     * hard to test w/o connecting to an ES server
+    'can run register function' : function (test) {
+        test.expect(1);
+        test.doesNotThrow(this.plugin.register());
+        test.done();
+    },
+    */
+};
+
+exports.load_es_ini = {
+    setUp : _set_up,
+    'can load log.elasticsearch.ini' : function (test) {
+        test.expect(2);
+        this.plugin.load_es_ini();
+        test.ok(this.plugin.cfg);
+        test.ok(this.plugin.cfg.index);
+        test.done();
+    },
+};
+
+exports.objToArray = {
+    setUp : _set_up,
+    'converts an object to an array of key vals' : function (test) {
+        test.expect(2);
+        test.deepEqual([{k: 'foo', v: 'bar'}],
+                this.plugin.objToArray({ foo: 'bar' }));
+        test.deepEqual([{k: 'foo', v: 'bar'}, {k: 'baz', v: 'wuz'}],
+                this.plugin.objToArray({ foo: 'bar', baz: 'wuz' }));
+        test.done();
+    },
+};
+
+exports.getIndexName = {
+    setUp : _set_up,
+    'gets index name for cxn or txn' : function (test) {
+        test.expect(4);
+        this.plugin.cfg = { index: {} };
+        test.ok( /smtp\-connection\-/
+                .test(this.plugin.getIndexName('connection')));
+        test.ok( /smtp\-transaction\-/
+                .test(this.plugin.getIndexName('transaction')));
+
+        this.plugin.cfg.index.connection = 'cxn';
+        this.plugin.cfg.index.transaction = 'txn';
+        test.ok( /cxn\-/.test(this.plugin.getIndexName('connection')));
+        test.ok( /txn\-/.test(this.plugin.getIndexName('transaction')));
+        test.done();
+    }
+};
+
+exports.populate_conn_properties = {
+    setUp : _set_up,
+    'adds conn.local' : function (test) {
+        test.expect(1);
+        this.connection.local_ip= '127.0.0.3';
+        this.connection.local_port= '25';
+        var result = {};
+        var expected = { ip: '127.0.0.3', port: '25' };
+        this.plugin.load_es_ini();
+        this.plugin.populate_conn_properties(this.connection, result);
+        delete result.local.host;
+        test.deepEqual(expected, result.local);
+        test.done();
+    },
+    'adds conn.remote' : function (test) {
+        test.expect(1);
+        this.connection.remote_ip='127.0.0.4';
+        this.connection.remote_port='2525';
+        var result = {};
+        var expected = { ip: '127.0.0.4', port: '2525' };
+        this.plugin.load_es_ini();
+        this.plugin.populate_conn_properties(this.connection, result);
+        delete result.remote.host;
+        test.deepEqual(expected, result.remote);
+        test.done();
+    },
+    'adds conn.helo' : function (test) {
+        test.expect(1);
+        this.connection.hello_host='testimerson';
+        this.connection.greeting='EHLO';
+        var result = {};
+        var expected = { host: 'testimerson', verb: 'EHLO' };
+        this.plugin.load_es_ini();
+        this.plugin.populate_conn_properties(this.connection, result);
+        delete result.remote.host;
+        test.deepEqual(expected, result.hello);
+        test.done();
+    },
+    'adds conn.count' : function (test) {
+        test.expect(1);
+        this.connection.errors=1;
+        this.connection.tran_count=2;
+        this.connection.msg_count= { accept: 0 };
+        this.connection.rcpt_count= { reject: 1 };
+        var result = {};
+        var expected = {errors: 1, trans: 2,
+            msg: { accept: 0 }, rcpt: { reject: 1 }
+        };
+        this.plugin.load_es_ini();
+        this.plugin.populate_conn_properties(this.connection, result);
+        delete result.remote.host;
+        test.deepEqual(expected, result.count);
+        test.done();
+    },
+};
+
+exports.get_plugin_results = {
+    setUp : _set_up,
+    'adds plugin results to results object' : function (test) {
+        test.expect(1);
+        this.plugin.load_es_ini();
+        this.connection.start_time = Date.now() - 1000;
+        this.connection.results.add(this.plugin, { pass: 'test' });
+        this.connection.results.add({name: 'queue'}, { pass: 'delivered' });
+        var expected_result = {
+            'log.elasticsearch': { pass: [ 'test' ] },
+            'queue': { pass: [ 'delivered' ] },
+        };
+        delete this.plugin.cfg.top_level_names;
+        var result = this.plugin.get_plugin_results(this.connection);
+        test.deepEqual(expected_result, result);
+        test.done();
+    },
+};
+
+exports.trimPluginName = {
+    setUp : _set_up,
+    'trims off connection phase prefixes' : function (test) {
+        test.expect(6);
+        test.equal('headers', this.plugin.trimPluginName('data.headers'));
+        test.equal('geoip', this.plugin.trimPluginName('connect.geoip'));
+        test.equal('asn', this.plugin.trimPluginName('connect.asn'));
+        test.equal('helo', this.plugin.trimPluginName('helo.checks'));
+        test.equal('qmail_deliverable',
+                this.plugin.trimPluginName('rcpt_to.qmail_deliverable'));
+        test.equal('is_resolvable',
+                this.plugin.trimPluginName('mail_from.is_resolvable'));
+        test.done();
+    },
+};


### PR DESCRIPTION
### change history
* merge transaction results into connection results
* get decoded message headers
* skip logging connection if already logged in transaction
* added exclude_hosts option
    handy for not polluting ES results with monitoring and testing connections
* add default config file
* move transaction "stored" node outside cb
    so that connections doesn't get stored if the transaction already did
* make ES index names configurable
* added config setting to nest plugin result inside another object
* add tests
* added log_connections option
* list of message headers to add is now a config setting
* the top level names (plugin, connection, message) are configuration with config options
* connection properties names can be aliased with config settings in [report_as] block
* removed index map template (until the docs for the ES API I'm using exist, and I can figure out how to detect failures and report 'em, it's better to have a static map)
* new top level `message` object.
* list of connection properties to store is now configurable
* added auth info