### PR TITLE
karma: add rule tests for plugins with / in name

### DIFF
--- a/configfile.js
+++ b/configfile.js
@@ -8,7 +8,7 @@ var yaml = require('js-yaml');
 // for "ini" type files
 var regex = exports.regex = {
     section:        /^\s*\[\s*([^\]]*?)\s*\]\s*$/,
-    param:          /^\s*([\w@\._-]+)\s*=\s*(.*?)\s*$/,
+    param:          /^\s*([\w@\._\-\/]+)\s*=\s*(.*?)\s*$/,
     comment:        /^\s*[;#].*$/,
     line:           /^\s*(.*?)\s*$/,
     blank:          /^\s*$/,

--- a/tests/config.js
+++ b/tests/config.js
@@ -164,7 +164,8 @@ exports.get = {
         _test_get(test, '../tests/config/test.ini', null, null, null, {
             main: { bool_true: 'true', bool_false: 'false', str_true: 'true', str_false: 'false' },
             sect1: { bool_true: 'true', bool_false: 'false', str_true: 'true', str_false: 'false' },
-            whitespace: { str_no_trail: 'true', str_trail: 'true' }
+            whitespace: { str_no_trail: 'true', str_trail: 'true' },
+            funnychars: { 'results.auth/auth_base.fail': 'fun' }
         });
     },
 

--- a/tests/config/test.ini
+++ b/tests/config/test.ini
@@ -15,3 +15,6 @@ str_false=false
 [whitespace]
 str_no_trail=true
 str_trail=true 
+
+[funnychars]
+results.auth/auth_base.fail=fun

--- a/tests/configfile.js
+++ b/tests/configfile.js
@@ -111,6 +111,18 @@ exports.load_ini_config = {
         test.strictEqual(r.sect1.bool_false_default, false);
         test.done();
     },
+    'test.ini, funnychars, /' : function (test) {
+        test.expect(1);
+        var r = this.cfreader.load_ini_config('tests/config/test.ini');
+        test.strictEqual(r.funnychars['results.auth/auth_base.fail'], 'fun');
+        test.done();
+    },
+    'test.ini, funnychars, _' : function (test) {
+        test.expect(1);
+        var r = this.cfreader.load_ini_config('tests/config/test.ini');
+        test.strictEqual(r.funnychars['results.auth/auth_base.fail'], 'fun');
+        test.done();
+    },
 };
 
 exports.get_filetype_reader  = {

--- a/tests/plugins/karma.js
+++ b/tests/plugins/karma.js
@@ -310,6 +310,13 @@ exports.get_award_location = {
         test.equal(undefined, r);
         test.done();
     },
+    'results.auth/auth_base': function (test) {
+        test.expect(1);
+        this.connection.results.add({name: 'auth/auth_base'}, { fail: 'PLAIN' });
+        var r = this.plugin.get_award_location(this.connection, 'results.auth/auth_base');
+        test.equal('PLAIN', r.fail[0]);
+        test.done();
+    },
 };
 
 exports.get_award_condition = {
@@ -321,6 +328,13 @@ exports.get_award_condition = {
         ));
         test.equal(4000, this.plugin.get_award_condition(
             'results.geoip.distance@uniq', '-1 if gt 4000'
+        ));
+        test.done();
+    },
+    'auth/auth_base': function (test) {
+        test.expect(1);
+        test.equal('plain', this.plugin.get_award_condition(
+            'results.auth/auth_base.fail@plain', '-1 if in'
         ));
         test.done();
     },
@@ -361,6 +375,18 @@ exports.check_awards = {
         // test that the award was applied
         test.equal('geoip.distance', this.connection.results.get('karma').fail[0]);
 
+        test.done();
+    },
+    'auth failure': function (test) {
+        test.expect(2);
+        this.connection.results.add({name: 'karma'}, {
+            todo: { 'results.auth/auth_base.fail@PLAIN': '-1 if in' }
+        });
+        this.connection.results.add({name: 'auth/auth_base'},
+                {fail: 'PLAIN'});
+        var r = this.plugin.check_awards(this.connection);
+        test.equal(undefined, r);
+        test.equal('auth/auth_base.fail', this.connection.results.get('karma').fail[0]);
         test.done();
     },
 };


### PR DESCRIPTION
(such as auth/auth_*)

for @celesteking

This rule should have worked for you:
````
results.auth/auth_base.fail      = -4  if length gt 0
````

However, Haraka's custom ini parser didn't permit it to work because of the forward slash:
````
[ERROR] [-] [core] Invalid line in config file 'karma.ini': results.auth/auth_base.fail = -4  if length gt 0
````

So attached is also a commit which adds the '/' char to the permitted list.