### PR TITLE
toobusy plugin compatibility issues with Nodejs 0.12

### DIFF
--- a/docs/plugins/toobusy.md
+++ b/docs/plugins/toobusy.md
@@ -4,10 +4,10 @@ toobusy
 This plugin will stop Haraka accepting new connections when the event loop 
 latency is too high.
 
-See https://github.com/lloyd/node-toobusy for details.
+See https://github.com/STRML/node-toobusy for details.
 
-To use this plugin you have to install the 'toobusy' module by running
-'npm install toobusy' in your Haraka configuration directory.
+To use this plugin you have to install the 'toobusy-js' module by running
+'npm install toobusy-js' in your Haraka configuration directory.
 
 This plugin should be listed at the top of your config/plugins file so that 
 it runs before any other plugin that hooks lookup\_rdns.

--- a/plugins/toobusy.js
+++ b/plugins/toobusy.js
@@ -1,6 +1,6 @@
 // Stop accepting new connections when we are too busy
 
-var toobusy = require('toobusy');
+var toobusy = require('toobusy-js');
 var was_busy = false;
 
 exports.register = function () {


### PR DESCRIPTION
The toobusy plugin by llyod seems to be dead. A newly maintained fork has been created and can be found here:

https://github.com/STRML/node-toobusy

I'm recommending upgrading to this current fork. There doesn't seem to be any breaking changes, and this fork makes a good drop in replacement. I've updated the core plugin and docs. I suggest another point release to 2.6.2 since this is a breaking change for the latest node stable version.