### PR TITLE
add HTTP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .coveralls.yml
 Haraka
 *~
+bower_components

--- a/TODO
+++ b/TODO
@@ -52,9 +52,6 @@ Move the following plugins:
  - test_queue   -> queue/test_queue
 
 Built-in HTTP server
-- instead of each plugin bringing their own, and getting relegated to some
-  god-forsaken port number:
-- a dispatch mechanism, so each plugin gets their own URL space
 - uses the same TLS/SSL certs as smtpd
 - auth against SMTP-AUTH provider
 

--- a/config/graph.ini
+++ b/config/graph.ini
@@ -3,10 +3,6 @@
 ;db_file=:memory:
 db_file=graphlog.db
 
-; The port to listen on for http. Default: `8080`.
-http_addr=127.0.0.1
-http_port=8080
-
 ; Regular expression to match plugins to ignore for logging.
 ; Default: `queue|graph|relay`
 ignore_re=`queue|graph|relay`

--- a/config/http.ini
+++ b/config/http.ini
@@ -1,0 +1,7 @@
+
+; listen: the HTTP address:port(s) to listen on
+; default: [::]:80 (port 80 on all IPv4 and IPv6 addresses)
+; listen=[::]:80
+
+; docroot: the directory where web content is served from
+;docroot=/usr/local/haraka/html

--- a/http/Gruntfile.js
+++ b/http/Gruntfile.js
@@ -1,0 +1,72 @@
+/* jshint camelcase: false */
+module.exports = function(grunt) {
+
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-bower-install-simple');
+    grunt.loadNpmTasks('grunt-bower');
+
+    var bpSrc = [], bpDest = [];
+    [
+        "404.html",
+        "apple-touch-icon.png",
+        "crossdomain.xml",
+        "browserconfig.xml",
+        "favicon.ico",
+        "robots.txt"
+    ].forEach(function (file) {
+        bpSrc.push("dist/" + file);
+        bpDest.push("html/" + file);
+    });
+
+    // Project configuration.
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('../package.json'),
+        'bower-install-simple': {
+            options: {
+                color: true,
+                directory: 'bower_components'
+            },
+            'prod': {
+                options: {
+                    production: true
+                }
+            },
+        },
+        bower: {
+            prod: {
+                dest: 'html',
+                js_dest: 'html/js/vendor',
+                css_dest: 'html/css/vendor',
+                fonts_dest: 'html/fonts/vendor',
+                options: {
+                    expand: false,
+                    keepExpandedHierarchy: false,
+                    packageSpecific: {
+                        bootstrap: {
+                            files: [
+                                "dist/css/bootstrap.min.css",
+                                "dist/css/bootstrap-theme.min.css",
+                                "dist/js/bootstrap.min.js"
+                            ]
+                        },
+                        jquery: {
+                            files: [
+                                "dist/jquery.min.js"
+                            ]
+                        },
+                        "html5-boilerplate": {
+                            files: bpSrc
+                        }
+                    }
+                },
+            }
+        },
+        clean: {
+            bower: [ 'html/**/vendor' ],
+            boilerplate: bpDest,
+            // dist: ['node_modules', 'bower_components']
+        },
+    });
+
+    grunt.registerTask('default', ['bower-install-simple', 'bower']);
+};

--- a/http/bower.json
+++ b/http/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "haraka-httpd",
+  "version": "1.0.0",
+  "description": "Haraka HTTP for SMTPd",
+  "main": "server",
+  "keywords": [ "http", "watch" ],
+  "authors": [
+    "Matt Simerson"
+  ],
+  "license": "MIT",
+  "homepage": "http://haraka.github.io/",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "client/bower_components",
+    "test"
+  ],
+  "dependencies": {
+    "bootstrap": "~3.3.1",
+    "jquery": "~2.1.1",
+    "html5-boilerplate": "^5.0.0"
+  }
+}

--- a/http/html/index.html
+++ b/http/html/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title></title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <link rel="stylesheet" href="css/vendor/bootstrap.min.css">
+        <link rel="stylesheet" href="css/vendor/bootstrap-theme.min.css">
+    </head>
+    <body>
+        <!--[if lt IE 7]>
+            <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+        <![endif]-->
+
+        <ul id="tabList" class="nav nav-tabs" role="tablist navigation">
+            <li class="active"><a href="#home" role=tab data-toggle=tab>Home</a></li>
+        </ul>
+
+        <div id="bodyDivContainer" class="tab-content">
+            <div class="tab-pane fade in active" id="home">
+                <h1>Haraka, a mail server (MTA).</h1>
+
+                <p>You are visiting an installation of <a href="http://haraka.github.io">Haraka</a>.</p>
+            </div>
+        </div>
+
+        <script src="js/vendor/jquery.min.js"></script>
+        <script src="js/vendor/bootstrap.min.js"></script>
+    </body>
+</html>

--- a/http/package.json
+++ b/http/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "dependencies": {
+    "bower": "^1.3.12",
+    "express": "^4.x",
+    "express-session": "*",
+    "jquery": "^2.1.1"
+  },
+  "devDependencies": {
+    "grunt": "*",
+    "grunt-bower": "*",
+    "grunt-bower-install-simple": "^1.0.3",
+    "grunt-cli": "*",
+    "grunt-contrib-clean": "*"
+  }
+}


### PR DESCRIPTION
* server: add http child listeners
* server: only load http if configured
* http.ini: new config file
* updated plugins/graph for new HTTP server
* warn if http enabled but can't load express or ws
* add config/bower.json, Gruntfile, package.json

### Pros
* allows multiple plugins to serve on the same HTTP(S) port
* provides an index/landing page
* closes #433 
* the basis for facilities to manage the outbound queue (@baudehlo in #443)

### Known Issues
* ~~the html/* directory is not included. Yet.~~ (installed with bower)
* ~~how to install web dependencies and avoid test failures re: them? (optionalDeps isn't ideal)~~ (bower)
* ~~docroot handling for haraka and per-plugin~~ (each plugin registers a route)

### Future Ideas
* populate plugin tabs dynamically (based on plugins that register routes)
* auth via any SMTP-AUTH provider
* provide a consistent UI via standardised views/templates (@baudehlo in #443)

Reopens #734 