### PR TITLE
Fix timeout issue in dkim_verify

### DIFF
--- a/dkim.js
+++ b/dkim.js
@@ -406,6 +406,8 @@ DKIMObject.prototype.end = function () {
             }
             return self.result(null, ((verified) ? 'pass' : 'fail'));
         }
+        // We didn't find a valid DKIM record for this signature
+        return self.result('no key for signature', 'invalid');
     });
 };
 


### PR DESCRIPTION
Uncovered thanks to the Washington Post incorrectly publishing a TXT record instead of a CNAME:

`````
[smf@mail1-ec2 Haraka]$ host -t TXT sailthru._domainkey.e.washingtonpost.com
sailthru._domainkey.e.washingtonpost.com descriptive text "e.washingtonpost.com.sailthrudkim.com"
`````