### PR TITLE
Add Fisher-Yates shuffle to randomize lookup order in data.uribl

### DIFF
--- a/plugins/data.uribl.js
+++ b/plugins/data.uribl.js
@@ -5,6 +5,7 @@ var url       = require('url');
 var dns       = require('dns');
 var isIPv4    = require('net').isIPv4;
 var net_utils = require('./net_utils');
+var utils     = require('./utils');
 
 // Default regexps to extract the URIs from the message
 var numeric_ip = /\w{3,16}:\/+(\S+@)?(\d+|0[xX][0-9A-Fa-f]+)\.(\d+|0[xX][0-9A-Fa-f]+)\.(\d+|0[xX][0-9A-Fa-f]+)\.(\d+|0[xX][0-9A-Fa-f]+)/gi;
@@ -81,6 +82,7 @@ exports.do_lookups = function (connection, next, hosts, type) {
         return next();
     }
     connection.logdebug(plugin, '(' + type + ') found ' + hosts.length + ' items for lookup');
+    utils.shuffle(hosts);
 
     var j;
     var queries = {};
@@ -154,7 +156,7 @@ exports.do_lookups = function (connection, next, hosts, type) {
         }
     }
     // Randomize the order a bit
-    queries_to_run.sort(Math.round(Math.random())-0.25);
+    utils.shuffle(queries_to_run);
 
     if(!queries_to_run.length) {
         results.add(plugin, {skip: type + ' (no queries)' });

--- a/utils.js
+++ b/utils.js
@@ -247,3 +247,22 @@ exports.base64 = function (str) {
 exports.unbase64 = function (str) {
     return new Buffer(str, "base64").toString("UTF-8");
 };
+
+// Fisher-Yates shuffle
+// http://bost.ocks.org/mike/shuffle/
+exports.shuffle = function(array) {
+  var m = array.length, t, i;
+
+  // While there remain elements to shuffle…
+  while (m) {
+      // Pick a remaining element…
+      i = Math.floor(Math.random() * m--);
+
+      // And swap it with the current element.
+      t = array[m];
+      array[m] = array[i];
+      array[i] = t;
+  }
+
+  return array;
+}


### PR DESCRIPTION
This is important in cases where there are a lot of URIs within a message to ensure that a random sample it looked up to the maximum query limit of each list.