### PR TITLE
Add anti-spoofing option to rcpt_to.in_host_list

### DIFF
--- a/bin/haraka
+++ b/bin/haraka
@@ -361,31 +361,22 @@ else if (parsed.order) {
                 (path.join(process.env.HARAKA, 'node_modules'));
         require('module')._initPaths(); // Horrible hack
     }
+    var sprintf = require('sprintf-js').sprintf;
     var logger = require(path.join(base, "logger"));
     if (!parsed.verbose)
         logger.log = function () {} // disable logging for this
     var plugins = require(path.join(base, "plugins"));
     plugins.load_plugins();
-    var hooks = ['init_master', 'init_child', 'lookup_rdns', 'connect', 'helo', 'ehlo', 
-                 'capabilities', 'unrecognized_command', 'mail', 'rcpt', 'rcpt_ok', 'data', 
-                 'max_data_exceeded', 'data_post', 'queue', 'queue_outbound','queue_ok', 
-                 'quit', 'disconnect', 'vrfy', 'noop', 'rset', 'reset_transaction', 'deny',
-                 'get_mx', 'bounce', 'delivered', 'send_email','deferred'];
     console.log('');
+    var hooks = Object.keys(plugins.registered_hooks);
     for (var h = 0; h < hooks.length; h++) {
         var hook = hooks[h];
-        console.log(hook + '\n----------------------');
-        for (var i = 0; i < plugins.plugin_list.length; i++) {
-            var plugin = plugins.plugin_list[i];
-            if (plugin && plugin.hooks[hook]) {
-                var j;
-                for (j = 0; j < plugin.hooks[hook].length; j++) {
-                    var hook_code_name = plugin.hooks[hook][j];
-                    (hook_code_name === 'hook_' + hook) ?
-                        console.log(plugin.name) :
-                        console.log(plugin.name + ' => ' + hook_code_name);
-                }
-            }
+        console.log(sprintf('%\'--80s', 'Hook: ' + hook + ' '));
+        console.log(sprintf('%-37s %-37s %-4s', 'Plugin', 'Method', 'Prio'));
+        console.log(sprintf("%'-80s",''));
+        for (var p=0; p<plugins.registered_hooks[hook].length; p++) {
+            var item = plugins.registered_hooks[hook][p];
+            console.log(sprintf('%-37s %-37s %4d', item.plugin, item.method, item.priority));
         }
         console.log('');
     }

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -249,10 +249,23 @@ This is important as some plugins might rely on `results` or `notes` that have
 been set by plugins that need to run before them.   This should be noted in the
 plugins documentation though, so you should make sure that you read it.
 
-If you are writing complex plugins of your own, you may find that you have to 
-split your plugins into multiple plugins if you require your hooks to run in a 
-specific order e.g. you want hook_deny to run last after all other plugins and
-hook_lookup_rdns to run first, then you'd need two plugins to achieve this.
+If you are writing complex plugins of your own, you may find that you require 
+your hooks to run in a specific order e.g. you want hook_deny to run last after 
+all other plugins and hook_lookup_rdns to run first, then you can explicitly 
+register your hooks and provide a `priority` value which is an integer between
+-100 (highest priority) to 100 (lowest priority) which defaults to 0 (zero) if
+not supplied.  You can apply a priority to your hook in the following way:
+
+`````
+exports.register = function() {
+    var plugin = this;
+    plugin.register_hook('connect',  'hook_connect', -100);
+}
+`````
+
+This would ensure that your hook_connect function will run before any other
+plugins registered on the `connect` hook, regardless of the order it was 
+specified in `config/plugins`.
 
 You can check the order that the plugins will run on each hook by running:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "author": "Matt Sergeant <helpme@gmail.com> (http://baudehlo.com/)",
   "name": "Haraka",
   "description": "An SMTP Server project.",
-  "keywords": ["haraka", "smtp", "server", "email"],
+  "keywords": [
+    "haraka",
+    "smtp",
+    "server",
+    "email"
+  ],
   "version": "2.6.1",
   "homepage": "http://haraka.github.io",
   "repository": {
@@ -14,45 +19,48 @@
     "node": ">= v0.8.0"
   },
   "dependencies": {
-    "nopt"          : "~2.1.2",
-    "generic-pool"  : "~2.0.2",
-    "iconv"         : "~2.1.0",
-    "ipaddr.js"     : "~0.1.2",
-    "semver"        : "~2.2.1",
-    "async"         : "~0.2.9",
-    "daemon"        : "~1.1.0",
-    "npid"          : "~0.4.0",
-    "address-rfc2822":"~0.0.2",
-    "js-yaml"       : "~3.2.3"
+    "nopt": "~2.1.2",
+    "generic-pool": "~2.0.2",
+    "iconv": "~2.1.0",
+    "ipaddr.js": "~0.1.2",
+    "semver": "~2.2.1",
+    "async": "~0.2.9",
+    "daemon": "~1.1.0",
+    "npid": "~0.4.0",
+    "address-rfc2822": "~0.0.2",
+    "js-yaml": "~3.2.3",
+    "sprintf-js": "~1.0.2"
   },
   "optionalDependencies": {
-    "node-syslog"   : "~1.1.7",
-    "strong-fork-syslog" : "~1.2.3",
-    "ldapjs"        : "~0.7.1",
-    "vs-stun"       : "~0.0.7",
-    "maxmind"       : "*",
-    "redis"         : "~0.10.1",
-    "tmp"           : "~0.0.24",
-    "haraka-nosql"  : "*"
+    "node-syslog": "~1.1.7",
+    "strong-fork-syslog": "~1.2.3",
+    "ldapjs": "~0.7.1",
+    "vs-stun": "~0.0.7",
+    "maxmind": "*",
+    "redis": "~0.10.1",
+    "tmp": "~0.0.24",
+    "haraka-nosql": "*"
   },
   "devDependencies": {
-    "nodeunit"      : "https://github.com/godsflaw/nodeunit/archive/master.tar.gz",
-    "jscoverage"    : "*",
-    "coveralls"     : "*"
+    "nodeunit": "https://github.com/godsflaw/nodeunit/archive/master.tar.gz",
+    "jscoverage": "*",
+    "coveralls": "*"
   },
-  "licenses": [ {
-    "type": "MIT",
-    "url": "https://github.com/baudehlo/Haraka/blob/master/LICENSE"
-  } ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/baudehlo/Haraka/blob/master/LICENSE"
+    }
+  ],
   "bugs": {
-    "mail" : "helpme@gmail.com",
-    "url" : "https://github.com/baudehlo/Haraka/issues"
+    "mail": "helpme@gmail.com",
+    "url": "https://github.com/baudehlo/Haraka/issues"
   },
-  "bin": { 
-    "haraka": "./bin/haraka", 
+  "bin": {
+    "haraka": "./bin/haraka",
     "spf": "./bin/spf",
     "dkimverify": "./bin/dkimverify",
-    "haraka_grep": "./bin/haraka_grep" 
+    "haraka_grep": "./bin/haraka_grep"
   },
   "scripts": {
     "test": "node run_tests",

--- a/plugins.js
+++ b/plugins.js
@@ -12,6 +12,10 @@ var utils       = require('./utils');
 var util        = require('util');
 var states      = require('./connection').states;
 
+exports.registered_hooks = {};
+exports.registered_plugins = {};
+exports.plugin_list = [];
+
 function Plugin(name) {
     this.name = name;
     this.base = {};
@@ -26,12 +30,26 @@ function Plugin(name) {
     this.hooks = {};
 }
 
-Plugin.prototype.register_hook = function(hook_name, method_name) {
+Plugin.prototype.register_hook = function(hook_name, method_name, priority) {
+    priority = parseInt(priority);
+    if (!priority) priority = 0;
+    if (priority > 100) priority = 100;
+    if (priority < -100) priority = -100;
+
+    if (!Array.isArray(exports.registered_hooks[hook_name])) {
+        exports.registered_hooks[hook_name] = [];
+    }
+    exports.registered_hooks[hook_name].push({
+        plugin: this.name,
+        method: method_name,
+        priority: priority
+    });
     this.hooks[hook_name] = this.hooks[hook_name] || [];
     this.hooks[hook_name].push(method_name);
 
-    logger.logdebug("registered hook " + hook_name + " to " + this.name + '.' +
-            method_name);
+    logger.logdebug("registered hook " + hook_name + 
+                    " to " + this.name + '.' + method_name +
+                    " priority " + priority);
 };
 
 Plugin.prototype.register = function () {}; // noop
@@ -50,7 +68,6 @@ Plugin.prototype.inherits = function (parent_name) {
 };
 
 Plugin.prototype._get_plugin_paths = function () {
-
     var paths = [ path.join(__dirname, './plugins') ];
 
     if (process.env.HARAKA) {
@@ -72,7 +89,6 @@ Plugin.prototype._get_plugin_paths = function () {
 };
 
 function get_timeout (name) {
-
     var timeout = parseFloat((config.get(name + '.timeout')));
     if (isNaN(timeout)) {
         logger.logdebug('no timeout in ' + name + '.timeout');
@@ -111,7 +127,23 @@ plugins.load_plugins = function () {
     logger.loginfo("Loading plugins");
     var plugin_list = config.get('plugins', 'list');
 
-    plugins.plugin_list = plugin_list.map(plugins.load_plugin);
+    plugin_list.forEach(function (plugin) {
+        plugins.load_plugin(plugin);
+    });
+
+    plugins.plugin_list = Object.keys(plugins.registered_plugins);
+
+    // Sort registered_hooks by priority
+    var hooks = Object.keys(plugins.registered_hooks);
+    for (var h=0; h<hooks.length; h++) {
+        var hook = hooks[h];
+        plugins.registered_hooks[hook].sort(function (a, b) {
+            if (a.priority < b.priority) return -1;
+            if (a.priority > b.priority) return 1;
+            return 0;
+        });
+    }
+
     logger.dump_logs(); // now logging plugins are loaded.
 };
 
@@ -123,6 +155,7 @@ plugins.load_plugin = function(name) {
         plugins._register_plugin(plugin);
     }
 
+    plugins.registered_plugins[name] = plugin;
     return plugin;
 };
 
@@ -240,15 +273,11 @@ plugins.run_hooks = function (hook, object, params) {
     }
     object.hooks_to_run = [];
 
-    for (var i = 0; i < plugins.plugin_list.length; i++) {
-        var plugin = plugins.plugin_list[i];
-
-        if (plugin && plugin.hooks[hook]) {
-            var j;
-            for (j = 0; j < plugin.hooks[hook].length; j++) {
-                var hook_code_name = plugin.hooks[hook][j];
-                object.hooks_to_run.push([plugin, hook_code_name]);
-            }
+    if (plugins.registered_hooks[hook]) {
+        for (var i=0; i<plugins.registered_hooks[hook].length; i++) {
+            var item = plugins.registered_hooks[hook][i];
+            var plugin = plugins.registered_plugins[item.plugin];
+            object.hooks_to_run.push([plugin, item.method]);
         }
     }
 


### PR DESCRIPTION
Based on the suggestion of GambitK on IRC last night.

I would usually suggest that the domains should set-up SPF and use the SPF plugin instead of this, but I can see a few scenarios where this might be better e.g.:

- This has far less overhead than SPF, so if this is checked first a lot of extra work can be avoided.
- The admin doesn't want to enable SPF rejections or use the SPF plugin at al..
- The admin might not be able to get SPF configured on a domain for some reason.