### PR TITLE
Update transaction.js

### DIFF
--- a/transaction.js
+++ b/transaction.js
@@ -146,7 +146,11 @@ Transaction.prototype.end_data = function(cb) {
         }
     }
 
-    this.message_stream.add_line_end(cb);
+    if (!this.discard_data) {
+        this.message_stream.add_line_end(cb);
+    } else {
+        cb();
+    }
 };
 
 Transaction.prototype.add_header = function(key, value) {


### PR DESCRIPTION
I had a bug when i discarded the data from the rcpt hook, it was crashing as the line was never called and therefore the write_ce.end never existed. checking the line again before calling the callback solved the problem. Tho i'm not sure if there is a better way to do it but this is my current fix.