### PR TITLE
Changing createCredentials to tls.createSecureContext

### DIFF
--- a/tls_socket.js
+++ b/tls_socket.js
@@ -194,7 +194,7 @@ function createServer(cb) {
                 if (options.requestCert !== undefined) { requestCert = options.requestCert; }
                 if (options.rejectUnauthorized !== undefined) { rejectUnauthorized = options.rejectUnauthorized; }
             }
-            var sslcontext = crypto.createCredentials(options);
+            var sslcontext = (tls.createSecureContext || crypto.createCredentials)(options);
 
             // tls.createSecurePair(credentials, isServer, requestCert, rejectUnauthorized)
             var pair = tls.createSecurePair(sslcontext, true, requestCert, rejectUnauthorized);
@@ -281,7 +281,7 @@ function connect(port, host, cb) {
         options.secureProtocol = options.secureProtocol || 'SSLv23_method';
         options.secureOptions  = options.secureOptions  || constants.SSL_OP_NO_SSLv3;
 
-        var sslcontext = crypto.createCredentials(options);
+        var sslcontext = (tls.createSecureContext || crypto.createCredentials)(options);
 
         // tls.createSecurePair([credentials], [isServer]);
         var pair = tls.createSecurePair(sslcontext, false);


### PR DESCRIPTION
I had a deprecation message when haraka start about createCredentials that told me to use the tls function instead.
Here is the doc: https://nodejs.org/api/crypto.html#crypto_crypto_createcredentials_details
It shows that it is the same options as well but i'm not sure about the bug mentioned in the file comment and how to exactly test it so if someone want me to make some more test with something specific let me know