### PR TITLE
connection: save queue results to result_store

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -188,6 +188,9 @@ logger.log_if_level = function (level, key, plugin) {
             else if (data instanceof plugins.Plugin) {
                 pluginstr = '[' + data.name + ']';
             }
+            else if (typeof data === 'object' && data.name) {
+                pluginstr = '[' + data.name + ']';
+            }
             else if (data instanceof outbound.HMailItem) {
                 pluginstr = '[outbound]';
                 if (data.todo && data.todo.uuid) {


### PR DESCRIPTION
### Goal
* make queue attempt failures visible to watch and elasticsearch plugins via result_store.

### change
* store queue result in transaction.results, providing more insight into what happened when queue attempts != 'ok'