### PR TITLE
Add anti-spoofing option to rcpt_to.in_host_list

### DIFF
--- a/docs/plugins/rcpt_to.in_host_list.md
+++ b/docs/plugins/rcpt_to.in_host_list.md
@@ -19,6 +19,13 @@ hook accepts the connection, it will be rejected.
   anchor with .\*. There is the potential for bad regexes to be
   too permissive if we don't anchor.
 
+* host\_list.anti\_spoof
+
+  When enabled, this will cause Haraka to reject any MAIL FROM where 
+  the host appears within the host list but the connected host is not
+  a relay, e.g. connection.relaying is not set either by SMTP AUTH or
+  another plugin like 'relay'.
+
 ## Relaying
 
 This plugin checks to see if the MAIL FROM domain is local. When


### PR DESCRIPTION
Re-opens #924 in a separate branch.

Based on the suggestion of GambitK on IRC last night.

I would usually suggest that the domains should set-up SPF and use the SPF plugin instead of this, but I can see a few scenarios where this might be better e.g.:

This has far less overhead than SPF, so if this is checked first a lot of extra work can be avoided.
The admin doesn't want to enable SPF rejections or use the SPF plugin at al..
The admin might not be able to get SPF configured on a domain for some reason.