### PR TITLE
limit: concurrent reject at connect (not rdns)

### DIFF
--- a/tests/plugins/limit.js
+++ b/tests/plugins/limit.js
@@ -134,12 +134,10 @@ exports.check_concurrency = {
             test.done();
         };
         var self = this;
-        self.connection.remote_ip='192.0.2.1';
         self.plugin.cfg.concurrency.history = undefined;
         self.plugin.cfg.concurrency = { max: 4 };
-        self.plugin.nosql.set('concurrency|192.0.2.1', 4, function () {
-            self.plugin.check_concurrency(cb, self.connection);
-        });
+        self.connection.notes.limit=4;
+        self.plugin.check_concurrency(cb, self.connection);
     },
     'too many': function (test) {
         test.expect(2);
@@ -150,12 +148,10 @@ exports.check_concurrency = {
             test.done();
         };
         var self = this;
-        self.connection.remote_ip='192.0.2.1';
         self.plugin.cfg.concurrency.history = undefined;
         self.plugin.cfg.concurrency = { max: 4 };
         self.plugin.cfg.concurrency.disconnect_delay=1;
-        self.plugin.nosql.set('concurrency|192.0.2.1', 5, function () {
-            self.plugin.check_concurrency(cb, self.connection);
-        });
+        self.connection.notes.limit=5;
+        self.plugin.check_concurrency(cb, self.connection);
     },
 };

--- a/tests/plugins/limit.js
+++ b/tests/plugins/limit.js
@@ -137,7 +137,9 @@ exports.check_concurrency = {
         self.connection.remote_ip='192.0.2.1';
         self.plugin.cfg.concurrency.history = undefined;
         self.plugin.cfg.concurrency = { max: 4 };
-        self.plugin.check_concurrency(cb, self.connection, 4);
+        self.plugin.nosql.set('concurrency|192.0.2.1', 4, function () {
+            self.plugin.check_concurrency(cb, self.connection);
+        });
     },
     'too many': function (test) {
         test.expect(2);
@@ -148,9 +150,12 @@ exports.check_concurrency = {
             test.done();
         };
         var self = this;
+        self.connection.remote_ip='192.0.2.1';
         self.plugin.cfg.concurrency.history = undefined;
         self.plugin.cfg.concurrency = { max: 4 };
         self.plugin.cfg.concurrency.disconnect_delay=1;
-        self.plugin.check_concurrency(cb, self.connection, 5);
+        self.plugin.nosql.set('concurrency|192.0.2.1', 5, function () {
+            self.plugin.check_concurrency(cb, self.connection);
+        });
     },
 };


### PR DESCRIPTION
Remember issue #947 where plugins that do anything other than next(CONT) at lookup_rdns cause me issues? This still increments the concurrency at lookup_rdns but waits until hook_connect to DENY. 