### PR TITLE
add Gruntfile.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ node_js:
     - "0.10"
 #   - "0.8"   # no longer supported by iconv
 #   - "0.6"   # no longer supported by async
-    - iojs
+    - "iojs-v1.8.1"
+    - "iojs"
 
 services:
     - redis-server
@@ -12,6 +13,7 @@ services:
 matrix:
     allow_failures:
         - node_js: "0.8"
+        - node_js: "iojs"
 #       - node_js: "0.6"
 
 after_success:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,33 @@
+module.exports = function(grunt) {
+
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-version-check');
+
+    // Project configuration.
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        jshint: {
+            options: {
+                jshintrc: true,
+            },
+            toplevel:[ '*.js' ],
+            bin:     [ 'bin/**/*.js' ],
+            plugins: [ 'plugins/**/*.js' ],
+            test:    [ 'tests/**/*.js' ],
+            all:     [ '<%= jshint.nosql %>', '<%= jshint.test %>' ],
+        },
+        clean: {
+            cruft: ['npm-debug.log'],
+            dist: [ 'node_modules' ]
+        },
+        versioncheck: {
+            options: {
+              skip : ['semver', 'npm'],
+              hideUpToDate : false
+            }
+        },
+    });
+
+    grunt.registerTask('default', ['jshint']);
+};

--- a/package.json
+++ b/package.json
@@ -38,7 +38,11 @@
   "devDependencies": {
     "nodeunit"      : "https://github.com/godsflaw/nodeunit/archive/master.tar.gz",
     "jscoverage"    : "*",
-    "coveralls"     : "*"
+    "coveralls"     : "*",
+    "grunt"         : "*",
+    "grunt-contrib-clean" : "*",
+    "grunt-contrib-jshint" : "*",
+    "grunt-version-check" : "*"
   },
   "licenses": [ {
     "type": "MIT",

--- a/package.json
+++ b/package.json
@@ -14,16 +14,16 @@
     "node": ">= v0.8.0"
   },
   "dependencies": {
-    "nopt"          : "~2.1.2",
-    "generic-pool"  : "~2.0.2",
+    "nopt"          : "~3.0.1",
+    "generic-pool"  : "~2.2.0",
     "iconv"         : "~2.1.0",
-    "ipaddr.js"     : "~0.1.2",
+    "ipaddr.js"     : "~1.0.1",
     "semver"        : "~2.2.1",
-    "async"         : "~0.2.9",
+    "async"         : "~0.9.0",
     "daemon"        : "~1.1.0",
     "npid"          : "~0.4.0",
     "address-rfc2822":"~0.0.2",
-    "js-yaml"       : "~3.2.3"
+    "js-yaml"       : "~3.3.0"
   },
   "optionalDependencies": {
     "node-syslog"   : "~1.1.7",


### PR DESCRIPTION
Our first grunt task:

```js
[matt@imac27] ~/Documents/git/haraka $ grunt versioncheck
Running "versioncheck" task
>> nopt (npm) is out of date. Your version: ~2.1.2 latest: 3.0.1
>> generic-pool (npm) is out of date. Your version: ~2.0.2 latest: 2.2.0
>> iconv (npm) is up to date.
>> ipaddr.js (npm) is out of date. Your version: ~0.1.2 latest: 1.0.1
>> async (npm) is out of date. Your version: ~0.2.9 latest: 0.9.0
>> daemon (npm) is up to date.
>> npid (npm) is up to date.
>> address-rfc2822 (npm) is up to date.
>> js-yaml (npm) is out of date. Your version: ~3.2.3 latest: 3.3.0
>> jscoverage (npm) is up to date.
>> coveralls (npm) is up to date.
>> grunt (npm) is up to date.
>> grunt-contrib-clean (npm) is up to date.
>> grunt-contrib-jshint (npm) is up to date.
>> grunt-version-check (npm) is up to date.

Done, without errors.
```

It compares all our dependencies with the versions on npm and reports the differences.