### PR TITLE
avg: result_store, defer options

### DIFF
--- a/docs/plugins/avg.md
+++ b/docs/plugins/avg.md
@@ -1,9 +1,8 @@
 # avg - Anti-Virus scanner
 
-This plug-in implements Anti-Virus scanning with AVG using the TCPD daemon which is available for Linux/FreeBSD and is [free for personal or commercial use](http://www.avg.com/gb-en/faq.pnuid-faq_v3_linux).
-It can be downloaded from [here](http://free.avg.com/gb-en/download.prd-alf).
+Implement virus scanning with AVG's TCPD daemon, available for Linux/FreeBSD. AVG linux is [free for personal or commercial use](http://www.avg.com/gb-en/faq.pnuid-faq_v3_linux) and can be downloaded from [free.avg.com](http://free.avg.com/gb-en/download.prd-alf).
 
-Any message that AVG considers to be infected will be rejected.  Any errors encountered will cause the plugin to return a temporary failure.
+Messages that AVG detects as infected are rejected. Errors will cause the plugin to return temporary failures unless the defer options are changed (see below).
 
 ## Configuration
 
@@ -24,3 +23,13 @@ The following options can be set in avg.ini:
 * session\_timeout
 
     Maximum number of seconds to wait for a reply to a command before failing.  A timeout will cause a temporary failure to be sent to the remote MTA.
+
+* [defer]
+
+By default, this plugin defers when errors or timeouts are encountered. To
+fail open (let messages pass when errors are enounctered), set the error
+and/or timeout values to false.
+
+    [defer]
+    error=true
+    timeout=true

--- a/plugins/avg.js
+++ b/plugins/avg.js
@@ -3,30 +3,56 @@
 
 // TODO: use pooled connections
 
-var fs = require('fs');
+var fs   = require('fs');
+var path = require('path');
 
 var sock = require('./line_socket');
 var smtp_regexp = /^([0-9]{3})([ -])(.*)/;
 
-exports.hook_data_post = function (next, connection) {
-    var self = this;
-    var txn = connection.transaction;
-    if (!txn) return next();
-    var cfg = this.config.get('avg.ini');
+exports.register = function () {
+    var plugin = this;
 
-    var tmpdir = cfg.main.tmpdir || '/tmp';
-    var tmpfile = tmpdir + '/' + txn.uuid + '.tmp';
-    var ws = fs.createWriteStream(tmpfile);
+    plugin.load_avg_ini();
+};
+
+exports.load_avg_ini = function () {
+    var plugin = this;
+
+    plugin.cfg = plugin.config.get('avg.ini', {
+        booleans: [
+            '+defer.timeout',
+            '+defer.error',
+        ],
+    }, function () {
+        plugin.load_avg_ini();
+    });
+};
+
+exports.get_tmp_file = function (transaction) {
+    var plugin = this;
+    var tmpdir  = plugin.cfg.main.tmpdir || '/tmp';
+    return path.join(tmpdir, transaction.uuid + '.tmp');
+};
+
+exports.hook_data_post = function (next, connection) {
+    var plugin = this;
+    if (!connection.transaction) return next();
+
+    var tmpfile = plugin.get_tmp_file(connection.transaction);
+    var ws      = fs.createWriteStream(tmpfile);
 
     ws.once('error', function(err) {
-        connection.logerror(self, 'Error writing temporary file: ' + err.message);
+        connection.results.add(plugin, {
+            err: 'Error writing temporary file: ' + err.message
+        });
+        if (!plugin.cfg.defer.error) return next();
         return next(DENYSOFT, 'Virus scanner error (AVG)');
     });
 
     ws.once('close', function() {
         var start_time = Date.now();
         var socket = new sock.Socket();
-        socket.setTimeout((cfg.main.connect_timeout || 10) * 1000);
+        socket.setTimeout((plugin.cfg.main.connect_timeout || 10) * 1000);
         var connected = false;
         var command = 'connect';
         var response = [];
@@ -38,31 +64,39 @@ exports.hook_data_post = function (next, connection) {
 
         socket.send_command = function (cmd, data) {
             var line = cmd + (data ? (' ' + data) : '');
-            connection.logprotocol(self, '> ' + line);
-            this.write(line + "\r\n");
+            connection.logprotocol(plugin, '> ' + line);
+            this.write(line + '\r\n');
             command = cmd.toLowerCase();
             response = [];
         };
 
         socket.on('timeout', function () {
-            connection.logerror(self, (connected ? 'connection' : 'session') +
-                ' timed out');
+            var msg = (connected ? 'connection' : 'session') +  ' timed out';
+            connection.results.add(plugin, { err: msg });
+            if (!plugin.cfg.defer.timeout) return do_next();
             return do_next(DENYSOFT, 'Virus scanner timeout (AVG)');
         });
+
         socket.on('error', function (err) {
-            connection.logerror(self, err.message);
+            connection.results.add(plugin, { err: err.message });
+            if (!plugin.cfg.defer.error) return do_next();
             return do_next(DENYSOFT, 'Virus scanner error (AVG)');
         });
+
         socket.on('connect', function () {
             connected = true;
-            this.setTimeout((cfg.main.session_timeout || 30) * 1000);
+            this.setTimeout((plugin.cfg.main.session_timeout || 30) * 1000);
         });
+
         socket.on('line', function (line) {
-            connection.logprotocol(self, '< ' + line);
             var matches = smtp_regexp.exec(line);
+            connection.logprotocol(plugin, '< ' + line);
             if (!matches) {
-                connection.logerror(self, 'Unrecognised response: ' + line);
+                connection.results.add(plugin,
+                    { err: 'Unrecognised response: ' + line,
+                });
                 socket.end();
+                if (!plugin.cfg.defer.error) return do_next();
                 return do_next(DENYSOFT, 'Virus scanner error (AVG)');
             }
 
@@ -70,13 +104,16 @@ exports.hook_data_post = function (next, connection) {
                 cont = matches[2],
                 rest = matches[3];
             response.push(rest);
-            if (cont !== ' ') return;
+            if (cont !== ' ') { return; }
 
             switch (command) {
                 case 'connect':
                     if (code !== '220') {
                         // Error
-                        connection.logerror(self, 'Unrecognised response: ' + line);
+                        connection.results.add(plugin, {
+                            err: 'Unrecognised response: ' + line,
+                        });
+                        if (!plugin.cfg.defer.timeout) return do_next();
                         return do_next(DENYSOFT, 'Virus scanner error (AVG)');
                     }
                     else {
@@ -86,35 +123,41 @@ exports.hook_data_post = function (next, connection) {
                 case 'scan':
                     var end_time = Date.now();
                     var elapsed = end_time - start_time;
-                    connection.loginfo(self, 'time=' + elapsed + 'ms ' +
-                         'code=' + code + ' ' +
-                         'response="' + response.join(' ') + '"');
+                    connection.loginfo(plugin, 'time=' + elapsed + 'ms ' +
+                                    'code=' + code + ' ' +
+                                    'response="' + response.join(' ') + '"');
                     // Check code
                     switch (code) {
                         case '200':  // 200 ok
                             // Message did not contain a virus
+                            connection.results.add(plugin, { pass: 'clean' });
                             socket.send_command('QUIT');
                             return do_next();
                         case '403':
                             // File 'eicar.com', 'Virus identified EICAR_Test'
-                            do_next(DENY, response.join(' '));
-                            return socket.send_command('QUIT');
+                            connection.results.add(plugin, {
+                                fail: response.join(' ')
+                            });
+                            socket.send_command('QUIT');
+                            return do_next(DENY, response.join(' '));
                         default:  
                             // Any other result is an error
-                            connection.logerror(self, 'Bad response: ' + response.join(' '));
+                            connection.results.add(plugin, {
+                                err: 'Bad response: ' + response.join(' ')
+                            });
                     }
                     socket.send_command('QUIT');
+                    if (!plugin.cfg.defer.error) return do_next();
                     return do_next(DENYSOFT, 'Virus scanner error (AVG)');
                 case 'quit':
                     socket.end();
                     break;
                 default:
                     throw new Error('Unknown command: ' + command);
-            
             }
         });
-        socket.connect((cfg.main.port || 54322), cfg.main.host);
+        socket.connect((plugin.cfg.main.port || 54322), plugin.cfg.main.host);
     });
 
-    txn.message_stream.pipe(ws, { line_endings: '\r\n' });
+    connection.transaction.message_stream.pipe(ws, { line_endings: '\r\n' });
 };


### PR DESCRIPTION
# Change Summary
* use path.join to assemble tmpfile (Windows friendly)
* move config loading into register()
* save results in result_store
* added two config file options
    * [defer]error=false
    * [defer]timeout=false

The motivation for the [defer] options is being able to test deploy this plugin in a safe manner. When there's an AVG engine/connection/network error, I don't want it to block all mail. The default behavior is still to defer on error/timeout, unless the config file options are set.
