### PR TITLE
rspamd: use connection properties vs plugin data

### DIFF
--- a/config/rspamd.ini
+++ b/config/rspamd.ini
@@ -1,11 +1,22 @@
-header_bar = X-Rspamd-Bar
-header_report = X-Rspamd-Report
-header_score = X-Rspamd-Score
 ;host = localhost
-;port = 11334
-;reject_message = Detected as spam
-;reject = true
+;port = 11333
 ;always_add_headers = false
-;spambar_positive = +
-;spambar_negative = -
-;spambar_neutral = /
+
+[header]
+bar = X-Rspamd-Bar
+report = X-Rspamd-Report
+score = X-Rspamd-Score
+
+[check]
+;authenticated=false
+;private_ip=false
+
+[reject]
+;message = Detected as spam
+;authenticated=false
+;spam = true
+
+[spambar]
+;positive = +
+;negative = -
+;neutral = /

--- a/docs/plugins/rspamd.md
+++ b/docs/plugins/rspamd.md
@@ -20,57 +20,76 @@ rspamd.ini
 
     Port Rspamd is listening on.
 
-- reject
-
-    Default: true
-
-    If set to false, ignore recommended *reject* action from Rspamd.
-
-- reject\_message
+- reject.message
 
     Default: Detected as spam
 
     Message to send when rejecting mail due to Rspamd policy recommendation.
 
-- always\_add_headers
+- reject.spam
+
+    Default: true
+
+    If set to false, ignore recommended *reject* action from Rspamd (except
+    for authenticated users).
+
+- reject.authenticated
+
+    Default: false
+
+    Reject messages from authenticated users if Rspamd recommends *reject*.
+
+- check.authenticated
+
+    Default: false
+
+    If true, messages from authenticated users will not be scanned by Rspamd.
+
+- check.private\_ip
+
+    Default: false
+
+    If true, messages from private IPs will not be scanned by Rspamd.
+
+- always\_add\_headers
 
     Default: false
 
     If true, always add headers (otherwise only do this when Rspamd recommends
     *add header* action).
 
-- header\_bar
+- header.bar
 
     Default: undefined
 
     If set, add a visual spam level in a header with this name.
 
-- header\_report
+- header.report
 
     Default: undefined
 
     If set, add information about symbols matched & their scores in a header
     with this name.
 
-- header\_score
+- header.score
 
     Default: undefined
 
     If set, add the numeric spam score in a header with this name.
 
-- spambar\_positive
+- spambar.positive
 
     Default: +
 
     Used as character for visual spam-level where score is positive.
 
-- spambar\_negative
+- spambar.negative
 
     Default: -
 
     Used as character for visual spam-level where score is negative.
 
-- spambar\_neutral
+- spambar.neutral
 
     Default: /
 


### PR DESCRIPTION
as connection properties are much more likely to exist.

* if no fcrdns plugin, get hostname from connection.remote_host
* get helo from connection.remote_host (vs helo.checks, same data)
* convert rcpt_to objects to email addresses
* set Deliver-To for single-recipient transactions
* add scan timer
* include urls, emails, and messages which might be present in rspamd reply (edit
  config/results.ini to control which are logged)

# changes from @fatalbanana (original author)
* correct port comment in rspamd.ini
* added option to skip reject for authenticated users
* added option to skip scanning for authenticated users
