### PR TITLE
earlytalker: store results when relayclient talks early

### DIFF
--- a/plugins/early_talker.js
+++ b/plugins/early_talker.js
@@ -19,7 +19,13 @@ exports.load_config = function () {
 exports.early_talker = function(next, connection) {
     var plugin = this;
     if (!plugin.pause      ) { return next(); } // config set to 0
-    if (connection.relaying) { return next(); } // Don't pause AUTH/RELAY clients
+    if (connection.relaying) {   // Don't pause AUTH/RELAY clients
+        if (connection.early_talker) {
+            connection.results.add(plugin,
+                    { skip: 'an early talking relaying client?!'});
+        }
+        return next();
+    }
 
     setTimeout(function () {
         if (!connection.early_talker) { return next(); }


### PR DESCRIPTION
Part of this PR is a question: Why would you put that line `if (!connection.early_talker) { return next(); }` inside the setTimeout?  It looks to me like a non-optimization.

This also adds a log message when a relaying client trips over the early_talker plugin. Yes, I've seen it happen 3 times now, so I'm sure it's happening more often. Just not quite sure how often.