### PR TITLE
clamd: added reject options to clamd.ini

### DIFF
--- a/config/karma.ini
+++ b/config/karma.ini
@@ -239,3 +239,4 @@ transaction.results.rspamd.action    = -1 if equals greylist
 transaction.results.rspamd.score@h1  =  1 if lt 0
 transaction.results.rspamd.score@s5  = -1 if gt 6
 transaction.results.rspamd.score@s10 = -2 if gt 10
+

--- a/docs/plugins/clamd.md
+++ b/docs/plugins/clamd.md
@@ -62,6 +62,33 @@ The following options can be defined in clamd.ini;
   If the clamd limit is reached the plug-in will log a notice that
   this has happened and will allow the message though.
 
+### [reject]
+
+An optional reject section can offer control over when to reject connections.
+The default settings are shown. ClamAV recommends that hits coming from 
+SafeBrowsing / Phishing / Heuristics, Potentially Unwanted Applications, and
+UNOFFICIAL be used only for scoring.
+
+    * virus=true
+    * error=true
+
+The following reject options are disabled by default in clamd.conf. With a
+default ClamAV install, these will have no effect. When an admin enables in
+clamd.conf, Haraka with then, by default, reject such messages. Adjust these
+settings to suit.
+
+    * Broken.Executable=true
+    * Structured=true
+    * Encrypted=true
+    * PUA=true
+    * OLE2=true
+    * Safebrowsing=true
+    * UNOFFICIAL=true
+
+The following options are enabled by default in clamd but ClamAV suggests
+using them only for scoring.
+
+    * Phishing=false
 
 ## clamd.excludes
 
@@ -89,3 +116,4 @@ The following options can be defined in clamd.ini;
 # Phishing
 Heuristics.Phishing.*
 `````
+

--- a/tests/plugins/clamd.js
+++ b/tests/plugins/clamd.js
@@ -7,13 +7,13 @@ var stub         = require('../fixtures/stub'),
     ResultStore  = require('../../result_store');
 
 var _set_up = function (done) {
-    
+
     this.plugin = new Plugin('clamd');
     this.plugin.config = config;
     this.plugin.register();
-    
+
     this.connection = Connection.createConnection();
-    
+
     this.connection.transaction = {
         notes: {},
         results: new ResultStore(this.plugin),
@@ -38,6 +38,30 @@ exports.load_clamd_ini = {
         test.equal(26214400, cfg.max_size);
         test.equal(false, cfg.only_with_attachments);
         test.equal(false, cfg.randomize_host_order);
+        test.done();
+    },
+    'reject opts': function (test) {
+        test.expect(14);
+        test.equal(true, this.plugin.rejectRE.test('Encrypted.'));
+        test.equal(true, this.plugin.rejectRE.test('Heuristics.Structured.'));
+        test.equal(true, this.plugin.rejectRE.test(
+                    'Heuristics.Structured.CreditCardNumber'));
+        test.equal(true, this.plugin.rejectRE.test('Broken.Executable.'));
+        test.equal(true, this.plugin.rejectRE.test('PUA.'));
+        test.equal(true, this.plugin.rejectRE.test(
+                    'Heuristics.OLE2.ContainsMacros'));
+        test.equal(true, this.plugin.rejectRE.test('Heuristics.Safebrowsing.'));
+        test.equal(true, this.plugin.rejectRE.test(
+        'Heuristics.Safebrowsing.Suspected-phishing_safebrowsing.clamav.net'));
+        test.equal(true, this.plugin.rejectRE.test(
+                    'Sanesecurity.Junk.50402.UNOFFICIAL'));
+        test.equal(false, this.plugin.rejectRE.test(
+                    'Sanesecurity.UNOFFICIAL.oops'));
+        test.equal(false, this.plugin.rejectRE.test('Phishing'));
+        test.equal(false, this.plugin.rejectRE.test(
+                    'Heuristics.Phishing.Email.SpoofedDomain'));
+        test.equal(false, this.plugin.rejectRE.test('Suspect.Executable'));
+        test.equal(false, this.plugin.rejectRE.test('MattWuzHere'));
         test.done();
     },
 };


### PR DESCRIPTION
* allow connections to continue if clamd error or virus found
    * particularly useful if testing with multiple virus scanners, to compare
      detection rates
* easier to use than clamd.excludes
* sets appropriate defaults
* emit: true is the default for results.add( {err: ...}) (no need to specify)