### PR TITLE
permit result_store consumers to store data that

### DIFF
--- a/docs/Results.md
+++ b/docs/Results.md
@@ -171,3 +171,14 @@ Retrieve a matching pattern:
     if (r.has('plugin_name', 'pass', /^some_test/)) {
         // some_test passed (2x)
     }
+
+### Private Results
+
+To store structured data in results that are hidden from the human and
+human_html output, prefix the name of the key with an underscore.
+
+Example:
+
+```js
+connection.results.add(plugin, { _hidden: "some data' });
+```

--- a/result_store.js
+++ b/result_store.js
@@ -145,6 +145,7 @@ ResultStore.prototype.private_collate = function (result, name) {
 
     // anything not predefined in the result was purposeful, show it first
     for (var key in result) {
+        if (key[0] === '_') continue;  // ignore 'private' keys
         if (all_opts.indexOf(key) !== -1) continue;
         if (hide.length && hide.indexOf(key) !== -1) continue;
         if (Array.isArray(result[key]) && result[key].length === 0) continue;


### PR DESCRIPTION
doesn't show up in human or human_html output (by default)

This is already possible by adding hide= config settings in results.ini, this
establishes a convention for doing it by default for the underscore pattern.