### PR TITLE
karma: simplifying further

### DIFF
--- a/config/karma.ini
+++ b/config/karma.ini
@@ -15,6 +15,7 @@ expire_days = 60
 [asn]
 ; track karma for AS? (network neighborhood)
 enable=true
+;report_as=connect.asn
 
 
 [tarpit]
@@ -117,6 +118,7 @@ results.karma.neighbors@-3       = -1 if lt -3
 results.karma.neighbors@-5       = -3 if lt -5
 results.karma.neighbors@1        =  1 if gt  1
 results.karma.neighbors@100      =  1 if gt  100
+results.karma.fail@env_user_match = -2 if in fail
 
 results.connect.p0f.os_name@fbsd =  1 if match freebsd
 results.connect.p0f.os_name@win  = -2 if match windows

--- a/config/karma.ini
+++ b/config/karma.ini
@@ -113,22 +113,31 @@ me=-1
 results.connect.geoip.distance@4 = -1 if gt 4000
 results.connect.geoip.distance@8 = -1 if gt 8000
 
-results.karma.neighbors@-1       = -1 if lt -1
-results.karma.neighbors@-3       = -1 if lt -3
-results.karma.neighbors@-5       = -3 if lt -5
-results.karma.neighbors@1        =  1 if gt  1
-results.karma.neighbors@100      =  1 if gt  100
-results.karma.fail@env_user_match = -2 if in fail
+results.karma.fail@env_user_match    = -2 if in fail
+
+; based on IP history
+; results.karma.history@-1             = -1 if lt -1
+; results.karma.history@-3             = -1 if lt -3
+results.karma.pass@all_good          =  2 if in
+results.karma.fail@all_bad           = -2 if in
+
+; based on ASN history
+results.karma.pass@asn               =  1 if in
+results.karma.fail@asn               = -1 if in
+results.karma.pass@asn_all_good      =  2 if in
+results.karma.fail@asn_all_bad       = -2 if in
 
 results.connect.p0f.os_name@fbsd =  1 if match freebsd
 results.connect.p0f.os_name@win  = -2 if match windows
 
-results.connect.fcrdns.fcrdns@0  =  1 if length gt 0
-results.connect.fcrdns.fail@0    = -1 if length gt 0
-results.connect.fcrdns.fail@1    = -2 if length gt 1
-results.connect.fcrdns.no_rdns   = -3
-results.connect.fcrdns.ip_in_rdns= -1
-results.connect.fcrdns.generic_rdns = -1
+; give back the points penalized for running windows
+results.connect.fcrdns.fcrdns@outlook =  1 if match outlook.com
+results.connect.fcrdns.fcrdns@0       =  1 if length gt 0
+results.connect.fcrdns.fail@0         = -1 if length gt 0
+results.connect.fcrdns.fail@1         = -2 if length gt 1
+results.connect.fcrdns.no_rdns        = -3
+results.connect.fcrdns.ip_in_rdns     = -1
+results.connect.fcrdns.generic_rdns   = -1
 
 results.access.whitelist         =  8
 results.access.blacklist         = -7
@@ -136,21 +145,18 @@ results.access.blacklist         = -7
 ; results.access.pass@mail        =  8 if in pass mail_from.access.whitelist
 ; results.access.pass@rcpt        =  8 if in pass rcpt_to.access.whitelist
 
-; these are cumulative, failing multiple adds up fast
-results.dnsbl.fail@0             = -2 if length gt 0
-results.dnsbl.fail@1             = -2 if length gt 1
-results.dnsbl.fail@2             = -3 if length gt 2
-results.dnsbl.fail@3             = -4 if length gt 3
+; failing more than one dnsbl is a very bad omen
+results.dnsbl.fail@gt2           = -4 if length gt 1
 
-; Assign scores to specific DNSBLs
-; results.dnsbl.fail@b.barracudacentral.org = -4 if match
-; results.dnsbl.fail@truncate.gbudb.net     = -3 if match
-; results.dnsbl.fail@cbl.abuseat.org        = -2 if match
-; results.dnsbl.fail@psbl.surriel.com       = -2 if match
-; results.dnsbl.fail@bl.spamcop.net         = -3 if match
-; results.dnsbl.fail@dnsbl-1.uceprotect.net = -2 if match
-; results.dnsbl.fail@pbl.spamhaus.org       = -1 if match
-; results.dnsbl.fail@xbl.spamhaus.org       = -2 if match
+; Scores for specific DNSBLs
+results.dnsbl.fail@b.barracudacentral.org = -7 if match
+results.dnsbl.fail@truncate.gbudb.net     = -5 if match
+results.dnsbl.fail@cbl.abuseat.org        = -4 if match
+results.dnsbl.fail@psbl.surriel.com       = -6 if match
+results.dnsbl.fail@bl.spamcop.net         = -3 if match
+results.dnsbl.fail@dnsbl-1.uceprotect.net = -2 if match
+results.dnsbl.fail@pbl.spamhaus.org       = -1 if match
+results.dnsbl.fail@xbl.spamhaus.org       = -5 if match
 
 results.helo.checks.fail@valid_hostname = -1 if match
 results.helo.checks.pass@forward_dns    =  1 if match
@@ -186,11 +192,12 @@ results.rcpt_to.qmail_deliverable.fail@0 = -3 if length gt 0
 results.rcpt_to.qmail_deliverable.fail@1 = -3 if length gt 1
 results.rcpt_to.qmail_deliverable.fail@3 = -5 if length gt 3
 
-results.headers.pass@p3          =  1 if length gt 4
-results.headers.fail@f1          = -1 if length gt 0
-results.headers.fail@f2          = -3 if length gt 1
-results.headers.fail@f3          = -3 if length gt 2
-results.headers.fail@from_match  = -1 if match
+results.data.headers.pass@p3          =  1 if length gt 4
+results.data.headers.pass@from_match  =  1 if match
+results.data.headers.fail@f1          = -1 if length gt 0
+results.data.headers.fail@f2          = -3 if length gt 1
+results.data.headers.fail@f3          = -3 if length gt 2
+results.data.headers.fail@from_match  = -1 if match
 
 results.data.uribl.fail@1        = -3 if length gt 0
 results.data.uribl.fail@2        = -2 if length gt 1
@@ -199,6 +206,7 @@ results.data.uribl.fail@3        = -2 if length gt 2
 results.bounce.fail@1            = -5 if length gt 0
 
 notes.bounce@invalid             = -3 if equals
+
 notes.spamassassin.hits@h0       =  1 if lt 0
 notes.spamassassin.hits@h2       =  2 if lt -2
 notes.spamassassin.hits@h5       =  3 if lt -10
@@ -213,4 +221,21 @@ notes.spamassassin.hits@s8       = -2 if gt 8
 notes.spamassassin.hits@s9       = -4 if gt 9
 notes.spamassassin.hits@s20      = -10 if gt 20
 
-results.clamd.fail@phish         =  -6 if match
+transaction.results.clamd.fail@executable =  -4 if match
+transaction.results.clamd.fail@structured =  -3 if match
+transaction.results.clamd.fail@encrypted  =  -4 if match
+transaction.results.clamd.fail@pua        =  -4 if match
+transaction.results.clamd.fail@ole2       =  -5 if match
+transaction.results.clamd.fail@safebrows  =  -4 if match
+transaction.results.clamd.fail@unofficial =  -4 if match
+transaction.results.clamd.fail@phish      =  -3 if match
+transaction.results.clamd.fail@spam       =  -2 if match
+
+results.auth/auth_base.fail      = -4  if length gt 0
+
+transaction.results.rspamd.is_spam   = -4
+transaction.results.rspamd.action    = -1 if equals greylist
+
+transaction.results.rspamd.score@h1  =  1 if lt 0
+transaction.results.rspamd.score@s5  = -1 if gt 6
+transaction.results.rspamd.score@s10 = -2 if gt 10

--- a/docs/plugins/karma.md
+++ b/docs/plugins/karma.md
@@ -108,12 +108,17 @@ are accessible to other plugins as well.
 
 The karma result object contains at least the following:
 
-    connect: 0,       <- score for this connection
+    score: 0,         <- score for this connection
     history: 0,       <- score for all connections
-    total_connects: 0,
+       good: 0,       <- qty of past 'good' connections
+       bad: 0,        <- qty of past 'bad' connections
+    connections: 0,   <- total past connections
     pass: [],         <- tests that added positive karma
     fail: [],         <- tests that added negative karma
 
+If an IP has at least 5 connections and all are good or bad, and `all_good` or
+`all_bad` result will be added to the `pass` or `fail` test list. This are
+very good indicators of future connection quality and are scored in karma.ini.
 
 ### <a name="Neighbor_Reputation"></a>ASN / Network Neighborhood Reputation
 

--- a/docs/plugins/karma.md
+++ b/docs/plugins/karma.md
@@ -56,7 +56,7 @@ The reward is purposefully small, to permit good senders in bad neighborhoods th
 
 ### <a name="delay"></a>Connection Delays
 
-Connection delays (aka tarpitting, teergrubing, early talker) slow down a SMTP conversation by inserting artificial delays. Early talking is when a sender talks out of turn. Karma punishes early talkers and increases connection delays adaptively as connection quality changes.
+Connection delays (aka tarpitting, teergrubing, early talker) slow down a SMTP conversation by inserting artificial delays. Karma increases connection delays adaptively as connection quality changes.
 
 Karma's delay goals:
 
@@ -81,14 +81,14 @@ In practice, most naughty senders abandon the connection when forced to
 wait more than a handful of seconds. `max` sets the maximum delay between
 responses.
 
-When using `karma`, do not use Haraka's `tarpit` or `early_talker` plugins.
+When using `karma`, do not use Haraka's `tarpit` plugin.
 
 ## Included Tests
 
 Connection data that karma considers:
 
 * [IP Reputation](#IP_Reputation)
-* [Neighbor reputation](#Neighbor_Reputation) (the network ASN)
+* [ASN reputation](#Neighbor_Reputation)
 * DENY events by other plugins
 * envelope sender from a spammy TLD
 * [malformed envelope addresses](#malformed_env)
@@ -102,7 +102,7 @@ the results](#awards) of other plugins. See karma.ini for a rich set of examples
 ### <a name="IP_Reputation"></a>IP Reputation
 
 Karma records the number of good, bad, and total connections.  The results
-are accessible so that other plugins as well.
+are accessible to other plugins as well.
 
     var karma = connection.results.get('karma');
 
@@ -115,11 +115,12 @@ The karma result object contains at least the following:
     fail: [],         <- tests that added negative karma
 
 
-### <a name="Neighbor_Reputation"></a>Neighborhood Reputation (ASN)
+### <a name="Neighbor_Reputation"></a>ASN / Network Neighborhood Reputation
 
     [asn]
     enable=true    (default: true)
     award=2        (default: 1 point)
+    report_as
 
 When [asn]enable is true, karma records the number of good and bad
 connections from each ASN. If [asn]award is > 0, that many karma points
@@ -127,6 +128,17 @@ connections from each ASN. If [asn]award is > 0, that many karma points
 
 ASNs with less than 5 karma points in either direction are ignored.
 
+#### report\_as
+
+Store the ASN results as another plugin. Example: I set `report_as=connect.asn`, so that karma history for an ASN is reported with the ASN plugin data. A practical consequence of changing report_as is that the award location in karma.ini would need to change from:
+
+    results.karma.pass@asn_all_good =  2 if in
+    results.karma.fail@asn_all_bad  = -3 if in
+
+to: 
+
+    results.connect.asn.pass@asn_all_good =  2 if in
+    results.connect.asn.fail@asn_all_bad  = -3 if in
 
 ### <a name="malformed_env"></a>Malformed Envelope Addresses
 
@@ -160,8 +172,8 @@ To combat these bruteforce attacks several strategies are called for:
 ## LIMITATIONS
 
 Karma is most effective at filtering mail delivered by bots and rogue servers.
-Spam delivered by servers with good reputations flies past most of karma's
-checks. Expect to use karma *with* content filters.
+Spam delivered by servers with good reputations normally pass karma's checks.
+Expect to use karma *with* content filters.
 
 
 [p0f-url]: /manual/plugins/connect.p0f.html

--- a/tests/plugins/karma.js
+++ b/tests/plugins/karma.js
@@ -51,7 +51,7 @@ exports.results_init = {
         test.done();
     },
     'init, empty cfg': function (test) {
-        this.plugin.results_init(this.connection);
+        this.plugin.results_init(stub, this.connection);
         var r = this.connection.results.get('karma');
         test.expect(1);
         test.ok(r);
@@ -59,7 +59,7 @@ exports.results_init = {
     },
     'init, cfg': function (test) {
         this.plugin.cfg.awards = { test: 1 };
-        this.plugin.results_init(this.connection);
+        this.plugin.results_init(stub, this.connection);
         var r = this.connection.results.get('karma');
         test.expect(2);
         test.ok(r);
@@ -180,25 +180,25 @@ exports.get_award_location = {
     },
     'results.karma': function (test) {
         test.expect(1);
-        this.connection.results.add({name: 'karma'}, { connect: -1 });
+        this.connection.results.add({name: 'karma'}, { score: -1 });
         var r = this.plugin.get_award_location(this.connection, 'results.karma');
         // console.log(r);
-        test.equal(-1, r.connect);
+        test.equal(-1, r.score);
         test.done();
     },
     'results.karma, txn': function (test) {
         // results should be found in conn or txn
         test.expect(1);
-        this.connection.transaction.results.add({name: 'karma'}, { connect: -1 });
+        this.connection.transaction.results.add({name: 'karma'}, { score: -1 });
         var r = this.plugin.get_award_location(this.connection, 'results.karma');
         // console.log(r);
-        test.equal(-1, r.connect);
+        test.equal(-1, r.score);
         test.done();
     },
     'txn.results.karma': function (test) {
         // these results shouldn't be found, b/c txn specified
         test.expect(1);
-        this.connection.results.add({name: 'karma'}, { connect: -1 });
+        this.connection.results.add({name: 'karma'}, { score: -1 });
         var r = this.plugin.get_award_location(this.connection, 'transaction.results.karma');
         // console.log(r);
         test.equal(undefined, r);
@@ -283,6 +283,17 @@ exports.check_awards = {
         test.equal('auth/auth_base.fail', this.connection.results.get('karma').fail[0]);
         test.done();
     },
+    'valid recipient': function (test) {
+        test.expect(2);
+        this.connection.results.add({name: 'karma'}, {
+            todo: { 'results.rcpt_to.qmd.pass@exist': '1 if in' }
+        });
+        this.connection.results.add({name: 'rcpt_to.qmd'}, {pass: 'exist'});
+        var r = this.plugin.check_awards(this.connection);
+        test.equal(undefined, r);
+        test.equal('qmd.pass', this.connection.results.get('karma').pass[0]);
+        test.done();
+    },
 };
 
 exports.apply_tarpit = {
@@ -350,7 +361,7 @@ exports.apply_tarpit = {
             test.done();
         };
         this.plugin.cfg.tarpit = { max: 1, delay: 0 };
-        this.connection.results.add(this.plugin, { connect: -2 });
+        this.connection.results.add(this.plugin, { score: -2 });
         this.plugin.apply_tarpit(this.connection, 'connect', -2, next);
     },
 };
@@ -383,7 +394,7 @@ exports.should_we_deny = {
             test.equal(undefined, msg);
             test.done();
         };
-        this.connection.results.add(this.plugin, { connect: 'blah' });
+        this.connection.results.add(this.plugin, { score: 'blah' });
         this.plugin.should_we_deny(next, this.connection, 'connect');
     },
     'valid score, okay': function (test) {
@@ -394,7 +405,7 @@ exports.should_we_deny = {
             test.done();
         }.bind(this);
         this.plugin.cfg.tarpit = { max: 1, delay: 0 };
-        this.connection.results.add(this.plugin, { connect: -1 });
+        this.connection.results.add(this.plugin, { score: -1 });
         this.plugin.should_we_deny(next, this.connection, 'connect');
     },
     'valid score, -6, deny_hook': function (test) {
@@ -406,7 +417,7 @@ exports.should_we_deny = {
         }.bind(this);
         this.plugin.cfg.tarpit = { max: 1, delay: 0 };
         this.plugin.deny_hooks = { connect: true};
-        this.connection.results.add(this.plugin, { connect: -6 });
+        this.connection.results.add(this.plugin, { score: -6 });
         this.plugin.should_we_deny(next, this.connection, 'connect');
     },
     'valid score, -6, pass_hook': function (test) {
@@ -418,7 +429,7 @@ exports.should_we_deny = {
         }.bind(this);
         this.plugin.cfg.tarpit = { max: 1, delay: 0 };
         this.plugin.deny_hooks = { helo: true };
-        this.connection.results.add(this.plugin, { connect: -6 });
+        this.connection.results.add(this.plugin, { score: -6 });
         this.plugin.should_we_deny(next, this.connection, 'connect');
     },
 };


### PR DESCRIPTION
* removed unused ipaddr.js
* rename connect to score (easier to understand what it is)
* in addition to computed history (good - bad), report good and bad
* be less verbose by default (when loglevel=info)
* don't tarpit quit (rarely works anyway)
* removed early_talker check
* added all_good and all_bad results
* on hook_deny, also permit DENYSOFTDISCONNECT to pass through
* moved static -1 penalty for env_user_match to karma.ini
* emit logs much less frequently
* added [asn]report_as feature