### PR TITLE
result_store: extend arrays instead of nesting

### DIFF
--- a/result_store.js
+++ b/result_store.js
@@ -55,7 +55,12 @@ ResultStore.prototype.add = function (plugin, obj) {
     for (var i=0; i < append_lists.length; i++) {
         var key = append_lists[i];
         if (!obj[key]) continue;
-        result[key].push(obj[key]);
+        if (Array.isArray(obj[key])) {
+            result[key] = result[key].concat(obj[key]);
+        }
+        else {
+            result[key].push(obj[key]);
+        }
     }
 
     // these arrays are overwritten when passed
@@ -113,7 +118,12 @@ ResultStore.prototype.push = function (plugin, obj) {
 
     for (var key in obj) {
         if (!result[key]) result[key] = [];
-        result[key].push( obj[key] );
+        if (Array.isArray(obj[key])) {
+            result[key] = result[key].concat(obj[key]);
+        }
+        else {
+            result[key].push(obj[key]);
+        }
     }
 };
 

--- a/tests/result_store.js
+++ b/tests/result_store.js
@@ -4,6 +4,8 @@ var stub         = require('./fixtures/stub'),
     config       = require('../config'),
     ResultStore  = require('../result_store');
 
+var plugin = {name: 'test_plugin'};
+
 function _set_up(callback) {
     this.connection = Connection.createConnection();
     this.connection.results = new ResultStore(this.connection);
@@ -18,7 +20,7 @@ exports.default_result = {
     tearDown : _tear_down,
     'init add' : function (test) {
         test.expect(1);
-        this.connection.results.add({name: 'test_plugin'}, { pass: 'test pass' });
+        this.connection.results.add(plugin, { pass: 'test pass' });
         delete this.connection.results.store.test_plugin.human;
         delete this.connection.results.store.test_plugin.human_html;
         test.deepEqual(
@@ -27,9 +29,21 @@ exports.default_result = {
                 );
         test.done();
     },
+    'init add array' : function (test) {
+        test.expect(1);
+        this.connection.results.add(plugin, { pass: 1 });
+        this.connection.results.add(plugin, { pass: [2,3] });
+        delete this.connection.results.store.test_plugin.human;
+        delete this.connection.results.store.test_plugin.human_html;
+        test.deepEqual(
+                { pass: [1,2,3], fail: [], msg: [], err: [], skip: [] },
+                this.connection.results.get('test_plugin')
+                );
+        test.done();
+    },
     'init incr' : function (test) {
         test.expect(1);
-        this.connection.results.incr({name: 'test_plugin'}, { counter: 1 });
+        this.connection.results.incr(plugin, { counter: 1 });
         delete this.connection.results.store.test_plugin.human;
         delete this.connection.results.store.test_plugin.human_html;
         test.deepEqual(
@@ -40,7 +54,7 @@ exports.default_result = {
     },
     'init push' : function (test) {
         test.expect(1);
-        this.connection.results.push({name: 'test_plugin'}, { pass: 'test1' });
+        this.connection.results.push(plugin, { pass: 'test1' });
         delete this.connection.results.store.test_plugin.human;
         delete this.connection.results.store.test_plugin.human_html;
         test.deepEqual(
@@ -49,9 +63,21 @@ exports.default_result = {
                 );
         test.done();
     },
+    'init push array' : function (test) {
+        test.expect(1);
+        this.connection.results.push(plugin, { pass: 'test1' });
+        this.connection.results.push(plugin, { pass: ['test2'] });
+        delete this.connection.results.store.test_plugin.human;
+        delete this.connection.results.store.test_plugin.human_html;
+        test.deepEqual(
+                { pass: ['test1','test2'], fail: [], msg: [], err: [], skip: [] },
+                this.connection.results.get('test_plugin')
+                );
+        test.done();
+    },
     'init push, other' : function (test) {
         test.expect(1);
-        this.connection.results.push({name: 'test_plugin'}, { other: 'test2' });
+        this.connection.results.push(plugin, { other: 'test2' });
         delete this.connection.results.store.test_plugin.human;
         delete this.connection.results.store.test_plugin.human_html;
         test.deepEqual(
@@ -67,14 +93,14 @@ exports.has = {
     tearDown : _tear_down,
     'has, list, string' : function (test) {
         test.expect(2);
-        this.connection.results.add({name: 'test_plugin'}, { pass: 'test pass' });
+        this.connection.results.add(plugin, { pass: 'test pass' });
         test.equal(true, this.connection.results.has('test_plugin', 'pass', 'test pass'));
         test.equal(false, this.connection.results.has('test_plugin', 'pass', 'test miss'));
         test.done();
     },
     'has, list, regexp' : function (test) {
         test.expect(3);
-        this.connection.results.add({name: 'test_plugin'}, { pass: 'test pass' });
+        this.connection.results.add(plugin, { pass: 'test pass' });
         test.ok(this.connection.results.has('test_plugin', 'pass', /test/));
         test.ok(this.connection.results.has('test_plugin', 'pass', / pass/));
         test.equal(this.connection.results.has('test_plugin', 'pass', /not/), false);
@@ -82,14 +108,14 @@ exports.has = {
     },
     'has, string, string' : function (test) {
         test.expect(2);
-        this.connection.results.add({name: 'test_plugin'}, { random_key: 'string value' });
+        this.connection.results.add(plugin, { random_key: 'string value' });
         test.ok(this.connection.results.has('test_plugin', 'random_key', 'string value'));
         test.equal(false, this.connection.results.has('test_plugin', 'random_key', 'strings'));
         test.done();
     },
     'has, string, regex' : function (test) {
         test.expect(3);
-        this.connection.results.add({name: 'test_plugin'}, { random_key: 'string value' });
+        this.connection.results.add(plugin, { random_key: 'string value' });
         test.ok(this.connection.results.has('test_plugin', 'random_key', /string/));
         test.ok(this.connection.results.has('test_plugin', 'random_key', /value/));
         test.equal(false, this.connection.results.has('test_plugin', 'random_key', /miss/));


### PR DESCRIPTION
when adding results to a pre-defined result array (pass, fail, msg, err,
skip), if the result is itself an array, extend the result array with the
contents.

IE, the result ends up as this:

   [ 'result1', 'result2', 'result3' ]

instead of

    [ 'result1', [ 'result2', 'result3' ]]