### PR TITLE
package.json: make node 0.10 requirement official

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "main": "haraka.js",
   "engines": {
-    "node": ">= v0.8.0"
+    "node": ">= v0.10.0"
   },
   "dependencies": {
     "nopt"          : "~3.0.1",


### PR DESCRIPTION
iconv no longer supports 0.8, we've stopped Travis testing Haraka on 0.8.