### PR TITLE
smtp_forward: revert part of #962 w/overlap #950

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -1571,7 +1571,7 @@ Connection.prototype.queue_msg = function (retval, msg) {
 
     switch (retval) {
         case constants.ok:
-            return 'Message Queued (' + this.transaction.uuid + ')';
+            return 'Message Queued';
         case constants.deny:
         case constants.denydisconnect:
             return 'Message denied';
@@ -1605,6 +1605,7 @@ Connection.prototype.queue_outbound_respond = function(retval, msg) {
     var self = this;
     if (!msg) msg = this.queue_msg(retval, msg);
     this.store_queue_result(retval, msg);
+    msg = msg + ' (' + this.transaction.uuid + ')';
     if (retval !== constants.ok) {
         this.lognotice('queue code=' + constants.translate(retval) + ' msg="' + msg + '"');
     }
@@ -1657,7 +1658,9 @@ Connection.prototype.queue_outbound_respond = function(retval, msg) {
                         self.logerror("Unrecognised response from outbound layer: " + retval + " : " + msg);
                         self.respond(550, msg || "Internal Server Error", function() {
                             self.msg_count.reject++;
-                            self.reset_transaction(function () { self.resume();});
+                            self.reset_transaction(function () {
+                                self.resume();
+                            });
                         });
                 }
             });
@@ -1668,6 +1671,7 @@ Connection.prototype.queue_respond = function(retval, msg) {
     var self = this;
     if (!msg) msg = this.queue_msg(retval, msg);
     this.store_queue_result(retval, msg);
+    msg = msg + ' (' + this.transaction.uuid + ')';
 
     if (retval !== constants.ok) {
         this.lognotice('queue code=' + constants.translate(retval) + ' msg="' + msg + '"');

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -94,12 +94,7 @@ exports.hook_queue = function (next, connection) {
                 smtp_client.send_command('RSET');
                 return;
             }
-            var rs = connection.transaction ?
-                     connection.transaction.results :
-                     connection.results;
-            rs.add(plugin, { pass: smtp_client.response });
-            smtp_client.call_next(OK, smtp_client.response +
-                    ' (' + connection.transaction.uuid + ')');
+            smtp_client.call_next(OK, smtp_client.response);
             smtp_client.release();
         });
 
@@ -111,7 +106,7 @@ exports.hook_queue = function (next, connection) {
         smtp_client.on('bad_code', function (code, msg) {
             if (dead_sender()) return;
             smtp_client.call_next(((code && code[0] === '5') ? DENY : DENYSOFT),
-                                msg + ' (' + connection.transaction.uuid + ')');
+                                msg);
             smtp_client.release();
         });
     };

--- a/plugins/queue/smtp_proxy.js
+++ b/plugins/queue/smtp_proxy.js
@@ -37,7 +37,7 @@ exports.hook_mail = function (next, connection, params) {
                 return;
             }
 
-            smtp_client.call_next(OK, smtp_client.response + ' (' + connection.transaction.uuid + ')');
+            smtp_client.call_next(OK, smtp_client.response);
             smtp_client.release();
             delete connection.notes.smtp_client;
         });


### PR DESCRIPTION
### changes:

1. Don't save txn results in queue/smtp_forward, redundant with #950
2. Don't append txn ID to queue message in queue/smtp_*
3. Do append txn ID in connection.queue_*_respond

Question: Is there any reason for the txn ID to be appended? Log
messages are already prefixed with the txn ID and txn results already have
the txn ID available, so at that point, it's entirely redundant data.

Near as I can tell, the only reason to append it there is so that it's
returned to the sending MTA in queue_*_respond. If that's the case, I'd rather
append it there.

Thoughts?