### PR TITLE
add support for custom Outbound Received header value

### DIFF
--- a/config/outbound.ini
+++ b/config/outbound.ini
@@ -18,3 +18,6 @@
 
 ; always_split: default: false
 ; always_split=true
+
+; received_header (default: "Haraka outbound")
+; received_header=Haraka outbound

--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -57,6 +57,11 @@ session. When `always_split` is enabled, each recipient gets a queue entry and
 delivery in its own SMTP session. This carries a performance penalty but
 enables more flexibility in mail delivery and bounce handling.
 
+* `received_header`
+
+Default: "Haraka outbound". This text is attached as a `Received` header to
+all outbound mail just before it is queued.
+
 ### outbound.bounce\_message
 
 See "Bounce Messages" below for details.

--- a/outbound.js
+++ b/outbound.js
@@ -58,6 +58,9 @@ exports.load_config = function () {
     if (!cfg.ipv6_enabled && config.get('outbound.ipv6_enabled')) {
         cfg.ipv6_enabled = true;
     }
+    if (!cfg.received_header) {
+        cfg.received_header = config.get('outbound.received_header') || 'Haraka outbound';
+    }
 };
 exports.load_config();
 
@@ -424,7 +427,7 @@ exports.send_trans_email = function (transaction, next) {
         transaction.add_header('Date', date_to_str(new Date()));
     }
 
-    transaction.add_leading_header('Received', '(Haraka outbound); ' + date_to_str(new Date()));
+    transaction.add_leading_header('Received', '('+cfg.received_header+'); ' + date_to_str(new Date()));
 
     var deliveries = [];
     var always_split = cfg.always_split;


### PR DESCRIPTION
The header involved gets added to the transaction after the `queue_outbound` event which is the last event before `queue_ok` that can modify the transaction (if I'm understanding the code correctly). This change simply lets the value of that header be customized with a simple string in the config/outbound.ini file. The default remains 'Haraka outbound'.