### PR TITLE
Fix recipient log code when hook_rcpt_ok returns CONT

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -981,8 +981,9 @@ Connection.prototype.rcpt_ok_respond = function (retval, msg) {
     }
     var rcpt = this.transaction.rcpt_to[this.transaction.rcpt_to.length - 1];
     var dmsg = "recipient " + rcpt.format();
+    // Log OK instead of CONT as this hook only runs if hook_rcpt returns OK
     this.lognotice(dmsg + ' ' + [
-        'code=' + constants.translate(retval),
+        'code=' + constants.translate((retval === constants.cont ? constants.ok : retval)),
         'msg="' + (msg || '') + '"',
         'sender="' + this.transaction.mail_from.address() + '"',
     ].join(' '));


### PR DESCRIPTION
Discovered in #1021 - recipient log lines are normally logged by rcpt_respond() except when the hook returns OK which causes rcpt_ok_respond to do the logging instead - at which point CONT doesn't make any sense, so we change it to OK instead for consistency as CONT at hook_rcpt should be impossible.