### PR TITLE
attach: load regex files early and pre-compile

### DIFF
--- a/docs/plugins/attachment.md
+++ b/docs/plugins/attachment.md
@@ -36,23 +36,28 @@ Configuration
 -------------
 
 * attachment.ini
+    * default settings shown
 
-  - archive\_max\_depth
-    (default: 5)
+  - timeout=30
+
+    Timeout in seconds before the plugin will abort.
+
+  - disallowed_extensions=exe,com,pif,bat,scr,vbs,cmd,cpl,dll
+
+    File extensions that should be rejected when detected.
+
+    [archive]
+  - max\_depth=5
 
     The maximum level of nested archives that will be unpacked.
     If this is exceeded the message will be rejected.
 
-  - archive\_extns
-    (default: .zip,.tar,.tgz,.taz,.z,.gz,.rar,.7z) 
+    [archive]
+  - extensions=zip,tar,tgz,taz,z,gz,rar,7z
 
     File extensions that should be treated as archives.
     This can be any file type supported by bsdtar.
 
-  - timeout
-    (default: 30)
-
-    Timeout in seconds before the plugin will abort.
 
 * attachment.filename.regex
 

--- a/tests/plugins/attachment.js
+++ b/tests/plugins/attachment.js
@@ -1,0 +1,82 @@
+'use strict';
+
+var stub             = require('../fixtures/stub');
+var Connection       = require('../fixtures/stub_connection');
+var Plugin           = require('../fixtures/stub_plugin');
+var config           = require('../../config');
+var ResultStore      = require("../../result_store");
+
+var _set_up = function (done) {
+    
+    this.plugin = new Plugin('attachment');
+
+    this.plugin.config = config;
+    this.plugin.cfg = { main: {} };
+
+    this.connection = Connection.createConnection();
+
+    this.connection.transaction = stub;
+    this.connection.transaction.results = new ResultStore(this.plugin);
+    this.connection.transaction.notes = {};
+
+    done();
+};
+
+exports.attachment_ini = {
+    setUp : _set_up,
+    'load config': function (test) {
+        test.expect(2);
+        this.plugin.load_attachment_ini();
+        test.ok(this.plugin.cfg.archive.max_depth);
+        test.ok(this.plugin.cfg.archive.exts);
+        // console.log(this.plugin.cfg.archive.exts);
+        test.done();
+    },
+    'options_to_object': function (test) {
+        test.expect(1);
+        test.deepEqual(
+            {'.gz':true,'.zip':true}, 
+            this.plugin.options_to_object('gz zip')
+        );
+        test.done();
+    },
+};
+
+/* jshint maxlen: 100 */
+exports.load_dissallowed_extns = {
+    setUp : _set_up,
+    'loads comma separated options': function (test) {
+        test.expect(3);
+        // setup
+        this.plugin.cfg = { main: { disallowed_extensions: 'exe,scr' } };
+
+        this.plugin.load_dissallowed_extns();
+        test.ok(this.plugin.re.bad_extn);
+
+        var txn = this.connection.transaction;
+        txn.notes.attachment_files = ['naughty.exe'];
+        test.equal('exe', this.plugin.disallowed_extensions(txn));
+
+        txn.notes.attachment_files = ['good.pdf', 'naughty.exe'];
+        test.equal('exe', this.plugin.disallowed_extensions(txn));
+        test.done();
+    },
+    'loads space separated options': function (test) {
+        test.expect(4);
+        this.plugin.cfg = { main: { disallowed_extensions: 'dll tnef' } };
+
+        this.plugin.load_dissallowed_extns();
+        test.ok(this.plugin.re.bad_extn);
+
+        var txn = this.connection.transaction;
+        txn.notes.attachment_archive_files = ['icky.tnef'];
+        test.equal('tnef', this.plugin.disallowed_extensions(txn));
+
+        txn.notes.attachment_archive_files = ['good.pdf', 'naughty.dll'];
+        test.equal('dll', this.plugin.disallowed_extensions(txn));
+
+        txn.notes.attachment_archive_files = ['good.pdf', 'better.png'];
+        test.equal(false, this.plugin.disallowed_extensions(txn));
+        test.done();
+    },
+};


### PR DESCRIPTION
* them in advance (rather than upon every connection)
* add periods to file extensions when not present (ie, no longer required in config)
* fixed a doc-code mismatch
* store archive extensions in object instead of array
    * replace list.indexOf(thing) === -1 with !list[thing]
* added disallowed_extensions config option, which blocks attachments with
  those extensions in file attachments and archives.
* lots of delicious tests