### PR TITLE
auth_base: save auth results to 'auth' plugin result

### DIFF
--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -86,8 +86,12 @@ exports.check_user = function (next, connection, credentials, method) {
     var passwd_ok = function (valid, message) {
         if (valid) {
             connection.relaying = true;
-            connection.results.add({name:'relay'}, {pass: 'auth'});
-            connection.results.add(plugin, {pass: method});
+            connection.results.add({name:'relay'}, {pass: plugin.name});
+            connection.results.add({name:'auth'}, {
+                pass: plugin.name,
+                method: method,
+                user: credentials[0],
+            });
             connection.respond(235, ((message) ? message : "Authentication successful"), function () {
                 connection.authheader = "(authenticated bits=0)\n";
                 connection.auth_results('auth=pass (' +
@@ -103,7 +107,9 @@ exports.check_user = function (next, connection, credentials, method) {
             connection.notes.auth_fails = 0;
         }
         connection.notes.auth_fails++;
-        connection.results.add(plugin, {fail: method});
+        connection.results.add({name: 'auth'}, {
+            fail: plugin.name + '/' + method,
+        });
 
         connection.notes.auth_login_userlogin = null;
         connection.notes.auth_login_asked_login = false;


### PR DESCRIPTION
* store auth results in a static location (was: name of auth plugin, so a
  fishing expedition of active auth plugins was needed to find where to locate
  auth results)
* store auth method
* when saving to 'relay', replace the pass message of 'auth' with the auth
  plugin that succeeded.