### PR TITLE
Incorrect plugin name

### DIFF
--- a/plugins/rcpt_to.ldap.js
+++ b/plugins/rcpt_to.ldap.js
@@ -4,7 +4,7 @@ var util = require('util');
 
 exports.register = function() {
     var plugin = this;
-    plugin.inherits('host_list_base');
+    plugin.inherits('rcpt_to.host_list_base');
 
     try {
         plugin.ldap = require('ldapjs');


### PR DESCRIPTION
I had problems with a missing plugin while trying to rcpt_to.ldap -- looks like this inherits line should include the full name of the plugin or else it doesn't work.