### PR TITLE
geoip: fix two CRIT errors:

### DIFF
--- a/plugins/connect.geoip.js
+++ b/plugins/connect.geoip.js
@@ -258,8 +258,7 @@ exports.add_headers = function (next, connection) {
     var received = [];
 
     var rh = plugin.received_headers(connection);
-    if ( rh) { received.push(rh); }
-    if (!rh) { plugin.user_agent(connection); } // No received headers.
+    if (rh) received.push(rh);
 
     var oh = plugin.originating_headers(connection);
     if (oh) { received.push(oh); }
@@ -351,10 +350,13 @@ exports.received_headers = function (connection) {
         if (net_utils.is_private_ip(match[1])) continue;  // exclude private IP
 
         var gi = plugin.get_geoip(match[1]);
-        var country = gi.countryCode || gi.code || 'UNKNOWN';
-        connection.loginfo(plugin, 'received=' + match[1] +
-                ' country=' + country);
-        results.push(match[1] + ':' + country);
+        var country = gi ? (gi.countryCode || gi.code) : '';
+        var logmsg = 'received=' + match[1];
+        if (country) {
+            logmsg += ' country=' + country;
+            results.push(match[1] + ':' + country);
+        }
+        connection.loginfo(plugin, logmsg);
     }
     return results;
 };


### PR DESCRIPTION
Jun 18 11:28:50 node haraka[35247]: [CRIT] [B4AB32E7.1] [core] Plugin connect.geoip failed:
TypeError: Cannot read property 'countryCode' of undefined at Plugin.exports.received_headers

Jun 17 14:48:52 node haraka[43032]: [CRIT] [2AA87F05.1] [core] Plugin connect.geoip failed:
TypeError: Object [object Object] has no method 'user_agent'     at
Plugin.exports.add_headers (/usr/local/lib/node_modules/Haraka/plugins/connect.geoip.js:266:23)