### PR TITLE
early_talker: fix boolean being assigned as number

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -371,7 +371,7 @@ Connection.prototype._process_data = function() {
                 this_line = this_line.toString().replace(/\r?\n/,'');
                 this.logdebug('[early_talker] state=' + this.state + ' esmtp=' + this.esmtp + ' line="' + this_line + '"');
             }
-            this.early_talker = 1;
+            this.early_talker = true;
             // If you talk early, we're going to give you a delay
             setTimeout(function() { self._process_data(); }, this.early_talker_delay);
             break;


### PR DESCRIPTION
since I told ES that field is a boolean, it gets cranky about this

````
Jun 19 10:45:35 node haraka[97348]: [ERROR] [34C15870-6E62-41F1-A6DF-F749240EEC6E] [log.elasticsearch] MapperParsingException[failed to parse [conn.early_talker]]; nested: JsonParseException[Current token (VALUE_FALSE) not numeric, can not use numeric value accessors  at [Source: [B@457ee1bd; line: 1, column: 1010]]; 
````

related to #983 