### PR TITLE
access: use connection.hook to determine hook

### DIFF
--- a/docs/plugins/access.md
+++ b/docs/plugins/access.md
@@ -34,6 +34,13 @@ person you know that still uses it:
     aol.com
     !friend@aol.com
 
+### ANY results
+
+When a whitelisted email or domain matches, a `pass` result will be saved
+with the hook name (ex: connect:any). When a blacklisted email or domain
+matches, a `fail` result of the same syntax is stored. If neither match, a
+`msg` result is saved (ex: unlisted(connect:any)).
+
 ### ANY data
 
 In addition to checking for a domain in the envelope, ANY can also check in

--- a/plugins/access.js
+++ b/plugins/access.js
@@ -138,6 +138,7 @@ exports.get_domain = function (hook, connection, params) {
             if (connection.remote_host === 'Unknown') return;
             return connection.remote_host;
         case 'helo':
+        case 'ehlo':
             if (net_utils.is_ipv4_literal(params)) return;
             return params;
         case 'mail':
@@ -181,19 +182,19 @@ exports.any = function (next, connection, params) {
     var file = plugin.cfg.domain.any;
     var cr = connection.results;
     if (plugin.in_list('domain', 'any', '!'+org_domain)) {
-        cr.add(plugin, {pass: file, whitelist: true, emit: true});
+        cr.add(plugin, {pass: hook +':' + file, whitelist: true, emit: true});
         return next();
     }
 
     var email;
     if (hook === 'mail' || hook === 'rcpt') { email = params[0].address(); }
     if (email && plugin.in_list('domain', 'any', '!'+email)) {
-        cr.add(plugin, {pass: file, whitelist: true, emit: true});
+        cr.add(plugin, {pass: hook +':'+ file, whitelist: true, emit: true});
         return next();
     }
 
     if (plugin.in_list('domain', 'any', '!'+domain)) {
-        cr.add(plugin, {pass: file, whitelist: true, emit: true});
+        cr.add(plugin, {pass: hook +':'+ file, whitelist: true, emit: true});
         return next();
     }
 
@@ -375,7 +376,7 @@ exports.rcpt_to_access = function(next, connection, params) {
 
 exports.data_any = function(next, connection) {
     var plugin = this;
-    if (!plugin.cfg.check.data) {
+    if (!plugin.cfg.check.data && !plugin.cfg.check.any) {
         connection.transaction.results.add(plugin, {skip: 'data(disabled)'});
         return next();
     }

--- a/tests/plugins/access.js
+++ b/tests/plugins/access.js
@@ -192,9 +192,9 @@ exports.rdns_access = {
         this.plugin.init_config();
         this.plugin.init_lists();
         var cb = function (rc) {
-            // console.log(this.connection.results);
+            // console.log(this.connection.results.get('access'));
             test.equal(undefined, rc);
-            test.ok(this.connection.results.get('access').pass.length);
+            test.ok(this.connection.results.get('access').msg.length);
             test.done();
         }.bind(this);
         this.connection.remote_ip='1.1.1.1';
@@ -261,7 +261,7 @@ exports.helo_access = {
         var cb = function (rc) {
             var r = this.connection.results.get('access');
             test.equal(undefined, rc);
-            test.ok(r && r.pass && r.pass.length);
+            test.ok(r && r.msg && r.msg.length);
             test.done();
         }.bind(this);
         this.plugin.cfg.check.helo=true;
@@ -293,7 +293,7 @@ exports.mail_from_access = {
         this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(undefined, rc);
-            test.ok(this.connection.transaction.results.get('access').pass.length);
+            test.ok(this.connection.transaction.results.get('access').msg.length);
             test.done();
         }.bind(this);
         this.plugin.mail_from_access(cb, this.connection, [new Address('<list@unknown.com>')]);
@@ -359,7 +359,7 @@ exports.rcpt_to_access = {
         this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(undefined, rc);
-            test.ok(this.connection.transaction.results.get('access').pass.length);
+            test.ok(this.connection.transaction.results.get('access').msg.length);
             test.done();
         }.bind(this);
         this.plugin.rcpt_to_access(cb, this.connection, [new Address('<user@example.com>')]);

--- a/tests/plugins/access.js
+++ b/tests/plugins/access.js
@@ -11,6 +11,7 @@ var _set_up = function (done) {
 
     this.plugin = new Plugin('access');
     this.plugin.config = config;
+    this.plugin.register();
 
     this.connection = Connection.createConnection();
     this.connection.results = new ResultStore(this.connection);
@@ -21,6 +22,7 @@ var _set_up = function (done) {
     done();
 };
 
+/* jshint maxlen: 100 */
 exports.in_list = {
     setUp : _set_up,
     'white, mail': function (test) {
@@ -153,7 +155,6 @@ exports.load_re_file = {
     setUp : _set_up,
     'whitelist': function (test) {
         test.expect(3);
-        this.plugin.init_config();
         this.plugin.load_re_file('white', 'mail');
         test.ok(this.plugin.list_re);
         // console.log(this.plugin.temp);
@@ -189,8 +190,6 @@ exports.rdns_access = {
     setUp : _set_up,
     'no list': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             // console.log(this.connection.results.get('access'));
             test.equal(undefined, rc);
@@ -203,8 +202,6 @@ exports.rdns_access = {
     },
     'whitelist': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             // console.log(this.connection.results.get('access'));
             test.equal(undefined, rc);
@@ -219,8 +216,6 @@ exports.rdns_access = {
     },
     'blacklist': function (test) {
         test.expect(3);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc, msg) {
             // console.log(this.connection.results.get('access'));
             test.equal(DENYDISCONNECT, rc);
@@ -235,8 +230,6 @@ exports.rdns_access = {
     },
     'blacklist regex': function (test) {
         test.expect(3);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc, msg) {
             // console.log(this.connection.results.get('access'));
             test.equal(DENYDISCONNECT, rc);
@@ -256,8 +249,6 @@ exports.helo_access = {
     setUp : _set_up,
     'no list': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             var r = this.connection.results.get('access');
             test.equal(undefined, rc);
@@ -269,8 +260,6 @@ exports.helo_access = {
     },
     'blacklisted regex': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(DENY, rc);
             var r = this.connection.results.get('access');
@@ -289,8 +278,6 @@ exports.mail_from_access = {
     setUp : _set_up,
     'no lists populated': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(undefined, rc);
             test.ok(this.connection.transaction.results.get('access').msg.length);
@@ -300,8 +287,6 @@ exports.mail_from_access = {
     },
     'whitelisted addr': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(undefined, rc);
             test.ok(this.connection.transaction.results.get('access').pass.length);
@@ -312,8 +297,6 @@ exports.mail_from_access = {
     },
     'blacklisted addr': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(DENY, rc);
             test.ok(this.connection.transaction.results.get('access').fail.length);
@@ -324,8 +307,6 @@ exports.mail_from_access = {
     },
     'blacklisted domain': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(DENY, rc);
             test.ok(this.connection.transaction.results.get('access').fail.length);
@@ -337,8 +318,6 @@ exports.mail_from_access = {
     },
     'blacklisted domain, white addr': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(undefined, rc);
             test.ok(this.connection.transaction.results.get('access').pass.length);
@@ -355,8 +334,6 @@ exports.rcpt_to_access = {
     setUp : _set_up,
     'no lists populated': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(undefined, rc);
             test.ok(this.connection.transaction.results.get('access').msg.length);
@@ -366,8 +343,6 @@ exports.rcpt_to_access = {
     },
     'whitelisted addr': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(undefined, rc);
             test.ok(this.connection.transaction.results.get('access').pass.length);
@@ -378,8 +353,6 @@ exports.rcpt_to_access = {
     },
     'blacklisted addr': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(DENY, rc);
             test.ok(this.connection.transaction.results.get('access').fail.length);
@@ -390,8 +363,6 @@ exports.rcpt_to_access = {
     },
     'blacklisted domain': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(DENY, rc);
             test.ok(this.connection.transaction.results.get('access').fail.length);
@@ -403,8 +374,6 @@ exports.rcpt_to_access = {
     },
     'blacklisted domain, white addr': function (test) {
         test.expect(2);
-        this.plugin.init_config();
-        this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(undefined, rc);
             test.ok(this.connection.transaction.results.get('access').pass.length);


### PR DESCRIPTION
* move get_domain() into it's own function
* document what gets saved in results
    * no listing = unlisted(hook_name:any)
    * whitelist  = pass(hook:any)
    * blacklist  = fail(hook:any)
* un-nest load_access_ini
* remove nested and not-necessary callbacks in list loading functions
* use register() in test setup instead of calling each _init() function in each test