### PR TITLE
Fix JSON/YAML overrides

### DIFF
--- a/config.js
+++ b/config.js
@@ -69,3 +69,6 @@ config.arrange_args = function (args) {
 
     return [fs_name, fs_type, cb, options];
 };
+
+// Load smtp.json or smtp.yaml as early as possible
+var cfg = config.get('smtp.json');

--- a/haraka.js
+++ b/haraka.js
@@ -58,9 +58,6 @@ process.on('exit', function() {
     logger.dump_logs();
 });
 
-// Load smtp.json or smtp.yaml as early as possible
-var cfg = config.get('smtp.json');
-
 logger.log("NOTICE", "Starting up Haraka version " + exports.version);
 
 server.createServer();


### PR DESCRIPTION
This was partly broken by https://github.com/baudehlo/Haraka/commit/d8d74cea30938fc71270955ee87b126f1964e0f6 as the override works by replacing the cache for the filename, and it can't know the options being passed beforehand.

So to fix this - overrides are tracked and get_config_cache returns the bare name for these without the options.

Additionally - the smtp.json file wasn't being loaded early enough to override smtp.ini, loglevel etc., so that has moved to config.js instead of haraka.js.