### PR TITLE
results: permit a string or object as 1st arg

### DIFF
--- a/docs/Results.md
+++ b/docs/Results.md
@@ -161,12 +161,12 @@ Same thing with **has** (retrieve a string match):
         // some_test passed (1x)
     }
 
-So the syntax for using **has** is a little more pleasant.
+The syntax for using **has** is a little more pleasant.
 
 Both options require one to check for each reason which is unpleasant when
 and all we really want to know is if some\_test passed or not.
 
-Retrieve a matching pattern:
+To retrieve a matching pattern:
 
     if (r.has('plugin_name', 'pass', /^some_test/)) {
         // some_test passed (2x)

--- a/result_store.js
+++ b/result_store.js
@@ -21,8 +21,9 @@ function default_result () {
     return { pass: [], fail: [], msg: [], err: [], skip: [] };
 }
 
-ResultStore.prototype.has = function (plugin_name, list, search) {
-    var result = this.store[plugin_name];
+ResultStore.prototype.has = function (plugin, list, search) {
+    var name = this.resolve_plugin_name(plugin);
+    var result = this.store[name];
     if (!result) return false;
     if (!result[list]) return false;
     if (typeof result[list] === 'string') {
@@ -43,8 +44,7 @@ ResultStore.prototype.has = function (plugin_name, list, search) {
 };
 
 ResultStore.prototype.add = function (plugin, obj) {
-    var name = plugin.name;
-
+    var name = this.resolve_plugin_name(plugin);
     var result = this.store[name];
     if (!result) {
         result = default_result();
@@ -80,10 +80,11 @@ ResultStore.prototype.add = function (plugin, obj) {
 };
 
 ResultStore.prototype.incr = function (plugin, obj) {
-    var result = this.store[plugin.name];
+    var name = this.resolve_plugin_name(plugin);
+    var result = this.store[name];
     if (!result) {
         result = default_result();
-        this.store[plugin.name] = result;
+        this.store[name] = result;
     }
 
     for (var key in obj) {
@@ -95,7 +96,7 @@ ResultStore.prototype.incr = function (plugin, obj) {
 };
 
 ResultStore.prototype.push = function (plugin, obj) {
-    var name = plugin.name;
+    var name = this.resolve_plugin_name(plugin);
     var result = this.store[name];
     if (!result) {
         result = default_result();
@@ -116,7 +117,7 @@ ResultStore.prototype.push = function (plugin, obj) {
 };
 
 ResultStore.prototype.collate = function (plugin) {
-    var name = plugin.name;
+    var name = this.resolve_plugin_name(plugin);
     var result = this.store[name];
     if (!result) return;
     return this.private_collate(result, name).join(', ');
@@ -126,6 +127,12 @@ ResultStore.prototype.get = function (plugin_name) {
     var result = this.store[plugin_name];
     if (!result) return;
     return result;
+};
+
+ResultStore.prototype.resolve_plugin_name = function (thing) {
+    if (!thing) { return; }
+    if (typeof thing === 'string') { return thing; }
+    return thing.name;
 };
 
 ResultStore.prototype.get_all = function () {

--- a/tests/plugins/karma.js
+++ b/tests/plugins/karma.js
@@ -172,7 +172,7 @@ exports.get_award_location = {
     },
     'results.connect.geoip': function (test) {
         test.expect(1);
-        this.connection.results.add({name: 'connect.geoip'}, { country: 'US' });
+        this.connection.results.add('connect.geoip', { country: 'US' });
         var r = this.plugin.get_award_location(this.connection, 'results.connect.geoip');
         // console.log(r);
         test.equal('US', r.country);
@@ -180,7 +180,7 @@ exports.get_award_location = {
     },
     'results.karma': function (test) {
         test.expect(1);
-        this.connection.results.add({name: 'karma'}, { score: -1 });
+        this.connection.results.add('karma', { score: -1 });
         var r = this.plugin.get_award_location(this.connection, 'results.karma');
         // console.log(r);
         test.equal(-1, r.score);
@@ -189,7 +189,7 @@ exports.get_award_location = {
     'results.karma, txn': function (test) {
         // results should be found in conn or txn
         test.expect(1);
-        this.connection.transaction.results.add({name: 'karma'}, { score: -1 });
+        this.connection.transaction.results.add('karma', { score: -1 });
         var r = this.plugin.get_award_location(this.connection, 'results.karma');
         // console.log(r);
         test.equal(-1, r.score);
@@ -198,7 +198,7 @@ exports.get_award_location = {
     'txn.results.karma': function (test) {
         // these results shouldn't be found, b/c txn specified
         test.expect(1);
-        this.connection.results.add({name: 'karma'}, { score: -1 });
+        this.connection.results.add('karma', { score: -1 });
         var r = this.plugin.get_award_location(this.connection, 'transaction.results.karma');
         // console.log(r);
         test.equal(undefined, r);
@@ -206,7 +206,7 @@ exports.get_award_location = {
     },
     'results.auth/auth_base': function (test) {
         test.expect(1);
-        this.connection.results.add({name: 'auth/auth_base'}, { fail: 'PLAIN' });
+        this.connection.results.add('auth/auth_base', { fail: 'PLAIN' });
         var r = this.plugin.get_award_location(this.connection, 'results.auth/auth_base');
         test.equal('PLAIN', r.fail[0]);
         test.done();
@@ -244,7 +244,7 @@ exports.check_awards = {
     },
     'no todo': function (test) {
         test.expect(1);
-        this.connection.results.add({name: 'karma'}, { todo: { } });
+        this.connection.results.add('karma', { todo: { } });
         var r = this.plugin.check_awards(this.connection);
         test.equal(undefined, r);
         test.done();
@@ -253,17 +253,17 @@ exports.check_awards = {
         test.expect(2);
 
         // populate the karma result with a todo item
-        this.connection.results.add({name: 'karma'}, {
+        this.connection.results.add('karma', {
             todo: { 'results.connect.geoip.distance@4000': '-1 if gt 4000' }
         });
         // test a non-matching criteria
-        this.connection.results.add({name: 'connect.geoip'}, { distance: 4000 });
+        this.connection.results.add('connect.geoip', { distance: 4000 });
         // check awards
         this.plugin.check_awards(this.connection);
         test.equal(undefined, this.connection.results.get('karma').fail[0]);
 
         // test a matching criteria
-        this.connection.results.add({name: 'connect.geoip'}, { distance: 4001 });
+        this.connection.results.add('connect.geoip', { distance: 4001 });
         // check awards
         this.plugin.check_awards(this.connection);
         // test that the award was applied
@@ -273,10 +273,10 @@ exports.check_awards = {
     },
     'auth failure': function (test) {
         test.expect(2);
-        this.connection.results.add({name: 'karma'}, {
+        this.connection.results.add('karma', {
             todo: { 'results.auth/auth_base.fail@PLAIN': '-1 if in' }
         });
-        this.connection.results.add({name: 'auth/auth_base'},
+        this.connection.results.add('auth/auth_base',
                 {fail: 'PLAIN'});
         var r = this.plugin.check_awards(this.connection);
         test.equal(undefined, r);
@@ -285,10 +285,10 @@ exports.check_awards = {
     },
     'valid recipient': function (test) {
         test.expect(2);
-        this.connection.results.add({name: 'karma'}, {
+        this.connection.results.add('karma', {
             todo: { 'results.rcpt_to.qmd.pass@exist': '1 if in' }
         });
-        this.connection.results.add({name: 'rcpt_to.qmd'}, {pass: 'exist'});
+        this.connection.results.add('rcpt_to.qmd', {pass: 'exist'});
         var r = this.plugin.check_awards(this.connection);
         test.equal(undefined, r);
         test.equal('qmd.pass', this.connection.results.get('karma').pass[0]);

--- a/tests/result_store.js
+++ b/tests/result_store.js
@@ -4,8 +4,6 @@ var stub         = require('./fixtures/stub'),
     config       = require('../config'),
     ResultStore  = require('../result_store');
 
-var plugin = {name: 'test_plugin'};
-
 function _set_up(callback) {
     this.connection = Connection.createConnection();
     this.connection.results = new ResultStore(this.connection);
@@ -20,7 +18,7 @@ exports.default_result = {
     tearDown : _tear_down,
     'init add' : function (test) {
         test.expect(1);
-        this.connection.results.add(plugin, { pass: 'test pass' });
+        this.connection.results.add('test_plugin', { pass: 'test pass' });
         delete this.connection.results.store.test_plugin.human;
         delete this.connection.results.store.test_plugin.human_html;
         test.deepEqual(
@@ -31,8 +29,8 @@ exports.default_result = {
     },
     'init add array' : function (test) {
         test.expect(1);
-        this.connection.results.add(plugin, { pass: 1 });
-        this.connection.results.add(plugin, { pass: [2,3] });
+        this.connection.results.add('test_plugin', { pass: 1 });
+        this.connection.results.add('test_plugin', { pass: [2,3] });
         delete this.connection.results.store.test_plugin.human;
         delete this.connection.results.store.test_plugin.human_html;
         test.deepEqual(
@@ -43,7 +41,7 @@ exports.default_result = {
     },
     'init incr' : function (test) {
         test.expect(1);
-        this.connection.results.incr(plugin, { counter: 1 });
+        this.connection.results.incr('test_plugin', { counter: 1 });
         delete this.connection.results.store.test_plugin.human;
         delete this.connection.results.store.test_plugin.human_html;
         test.deepEqual(
@@ -54,7 +52,7 @@ exports.default_result = {
     },
     'init push' : function (test) {
         test.expect(1);
-        this.connection.results.push(plugin, { pass: 'test1' });
+        this.connection.results.push('test_plugin', { pass: 'test1' });
         delete this.connection.results.store.test_plugin.human;
         delete this.connection.results.store.test_plugin.human_html;
         test.deepEqual(
@@ -65,8 +63,9 @@ exports.default_result = {
     },
     'init push array' : function (test) {
         test.expect(1);
-        this.connection.results.push(plugin, { pass: 'test1' });
-        this.connection.results.push(plugin, { pass: ['test2'] });
+        /* jshint maxlen: 100 */
+        this.connection.results.push('test_plugin', { pass: 'test1' });
+        this.connection.results.push('test_plugin', { pass: ['test2'] });
         delete this.connection.results.store.test_plugin.human;
         delete this.connection.results.store.test_plugin.human_html;
         test.deepEqual(
@@ -77,11 +76,12 @@ exports.default_result = {
     },
     'init push, other' : function (test) {
         test.expect(1);
-        this.connection.results.push(plugin, { other: 'test2' });
+        this.connection.results.push('test_plugin', { other: 'test2' });
         delete this.connection.results.store.test_plugin.human;
         delete this.connection.results.store.test_plugin.human_html;
         test.deepEqual(
-                { pass: [], other: ['test2'], fail: [], msg: [], err: [], skip: [] },
+                { pass: [], other: ['test2'], fail: [], msg: [],
+                  err: [], skip: [] },
                 this.connection.results.get('test_plugin')
                 );
         test.done();
@@ -91,16 +91,17 @@ exports.default_result = {
 exports.has = {
     setUp : _set_up,
     tearDown : _tear_down,
+    /* jshint maxlen: 100 */
     'has, list, string' : function (test) {
         test.expect(2);
-        this.connection.results.add(plugin, { pass: 'test pass' });
+        this.connection.results.add('test_plugin', { pass: 'test pass' });
         test.equal(true, this.connection.results.has('test_plugin', 'pass', 'test pass'));
         test.equal(false, this.connection.results.has('test_plugin', 'pass', 'test miss'));
         test.done();
     },
     'has, list, regexp' : function (test) {
         test.expect(3);
-        this.connection.results.add(plugin, { pass: 'test pass' });
+        this.connection.results.add('test_plugin', { pass: 'test pass' });
         test.ok(this.connection.results.has('test_plugin', 'pass', /test/));
         test.ok(this.connection.results.has('test_plugin', 'pass', / pass/));
         test.equal(this.connection.results.has('test_plugin', 'pass', /not/), false);
@@ -108,16 +109,16 @@ exports.has = {
     },
     'has, string, string' : function (test) {
         test.expect(2);
-        this.connection.results.add(plugin, { random_key: 'string value' });
+        this.connection.results.add('test_plugin', { random_key: 'string value' });
         test.ok(this.connection.results.has('test_plugin', 'random_key', 'string value'));
         test.equal(false, this.connection.results.has('test_plugin', 'random_key', 'strings'));
         test.done();
     },
     'has, string, regex' : function (test) {
         test.expect(3);
-        this.connection.results.add(plugin, { random_key: 'string value' });
-        test.ok(this.connection.results.has('test_plugin', 'random_key', /string/));
-        test.ok(this.connection.results.has('test_plugin', 'random_key', /value/));
+        this.connection.results.add('test_plugin', { random_key: 'string value' });
+        test.ok(this.connection.results.has( 'test_plugin', 'random_key', /string/));
+        test.ok(this.connection.results.has( 'test_plugin', 'random_key', /value/));
         test.equal(false, this.connection.results.has('test_plugin', 'random_key', /miss/));
         test.done();
     },


### PR DESCRIPTION
Note that this is just PR #910 reopened. Also note that a related change that makes this more useful now was merged in #950. Besides @celesteking 's purpose, I have since found another use for this feature (besides making the test writing syntax cleaner). That will come in a future PR.