### PR TITLE
permit loading of plugins in node_modules

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -24,6 +24,7 @@ function Plugin(name) {
     this._get_plugin_paths().forEach(function (pp) {
         full_paths.push(path.resolve(pp, name) + '.js');
         full_paths.push(path.resolve(pp, name) + '/index.js');
+        full_paths.push(path.resolve(pp, name) + '/package.json');
     });
     this.full_paths = full_paths;
     this.config = config;
@@ -48,7 +49,7 @@ Plugin.prototype.register_hook = function(hook_name, method_name, priority) {
     this.hooks[hook_name] = this.hooks[hook_name] || [];
     this.hooks[hook_name].push(method_name);
 
-    logger.logdebug("registered hook " + hook_name + 
+    logger.logdebug("registered hook " + hook_name +
                     " to " + this.name + '.' + method_name +
                     " priority " + priority);
 };
@@ -69,11 +70,7 @@ Plugin.prototype.inherits = function (parent_name) {
 };
 
 Plugin.prototype._get_plugin_paths = function () {
-    var paths = [ path.join(__dirname, './plugins') ];
-
-    if (process.env.HARAKA) {
-        paths.unshift(path.join(process.env.HARAKA, 'plugins'));
-    }
+    var paths = [];
 
     // Allow environment customized path to plugins in addition to defaults.
     // Multiple paths separated by (semi-)colon ':|;' depending on environment.
@@ -82,9 +79,17 @@ Plugin.prototype._get_plugin_paths = function () {
         process.env.HARAKA_PLUGIN_PATH.split(separator).map(function(p) {
             var pNorm = path.normalize(p);
             logger.logdebug('Adding plugin path: ' + pNorm);
-            paths.unshift(pNorm);
+            paths.push(pNorm);
         });
     }
+
+    if (process.env.HARAKA) {
+        paths.push(path.join(process.env.HARAKA, 'plugins'));
+        paths.push(path.join(process.env.HARAKA, 'node_modules'));
+    }
+
+    paths.push(path.join(__dirname, 'plugins'));
+    paths.push(path.join(__dirname, 'node_modules'));
 
     return paths;
 };

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -2,6 +2,7 @@
 
 var fs     = require('fs');
 var path   = require('path');
+var logger = require('../logger');
 var plugin = require('../plugins');
 
 var piName = 'testPlugin';
@@ -75,7 +76,10 @@ exports.get_plugin_paths = {
         test.expect(2);
         test.deepEqual(
             this.plugin._get_plugin_paths(),
-            [ path.join(__dirname, '../plugins') ],
+            [
+                path.join(__dirname, '../plugins'),
+                path.join(__dirname, '../node_modules'),
+            ],
             'default ./path'
         );
         test.deepEqual(
@@ -83,6 +87,10 @@ exports.get_plugin_paths = {
             [
                 path.join(__dirname, '../plugins/testPlugin.js'),
                 path.join(__dirname, '../plugins/testPlugin/index.js'),
+                path.join(__dirname, '../plugins/testPlugin/package.json'),
+                path.join(__dirname, '../node_modules/testPlugin.js'),
+                path.join(__dirname, '../node_modules/testPlugin/index.js'),
+                path.join(__dirname, '../node_modules/testPlugin/package.json'),
             ],
             'full_paths');
         test.done();
@@ -99,8 +107,10 @@ exports.get_plugin_paths = {
         test.deepEqual(
             this.plugin._get_plugin_paths(),
             [
-                path.join('/etc', '/haraka', '/plugins'),
-                path.join(__dirname, '../plugins')
+                path.join('/etc', 'haraka', 'plugins'),
+                path.join('/etc', 'haraka', 'node_modules'),
+                path.join(__dirname, '../plugins'),
+                path.join(__dirname, '../node_modules'),
             ],
             'default ./path'
         );
@@ -119,7 +129,8 @@ exports.get_plugin_paths = {
             this.plugin._get_plugin_paths(),
             [
                 path.join('/etc', '/haraka_plugins'),
-                path.join(__dirname, '../plugins')
+                path.join(__dirname, '../plugins'),
+                path.join(__dirname, '../node_modules'),
             ],
             'default + HARAKA_PLUGIN_PATH');
         test.done();


### PR DESCRIPTION
Order of plugin loading:

1. process.env.HARAKA_PLUGIN_PATH (if defined)
2. process.env.HARAKA/plugins
3. process.env.HARAKA/node_modules
4. __dir/plugins
5. __dir/node_modules


* __dir = Haraka config dir  (haraka -i this_value)
* process.env.HARAKA = Haraka install dir

closes #946 