### PR TITLE
load plugins from install directory's node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+!tests/node_modules
 .coveralls.yml
 Haraka
 *~

--- a/plugins.js
+++ b/plugins.js
@@ -200,26 +200,15 @@ plugins._load_and_compile_plugin = function (name) {
         }
         throw 'Loading plugin ' + name + ' failed: ' + last_err;
     }
-    var custom_require = function _haraka_require (module) {
-        if (!/^\./.test(module)) {
-            return require(module);
-        }
 
-        if (utils.existsSync(__dirname + '/' + module + '.js') ||
-            utils.existsSync(__dirname + '/' + module)) {
-            return require(module);
-        }
-
-        return require(path.dirname(fp[i]) + '/' + module);
-    };
     var code;
     if (hasPackageJson) {
-        code = '"use strict"; require("' + name + '");';
+        code = '"use strict"; var p = require("' + name + '"); for (var attrname in p) { exports[attrname] = p[attrname];}';
     } else {
         code = '"use strict";' + rf;
     }
     var sandbox = {
-        require: custom_require,
+        require: this._make_custom_require(fp[i], hasPackageJson),
         __filename: fp[i],
         __dirname:  path.dirname(fp[i]),
         exports: plugin,
@@ -391,6 +380,25 @@ plugins.run_next_hook = function (hook, object, params) {
         }
         callback();
     }
+};
+
+plugins._make_custom_require = function (file_path, hasPackageJson) {
+    return function (module) {
+        if (hasPackageJson) {
+            return require(module);
+        }
+
+        if (!/^\./.test(module)) {
+            return require(module);
+        }
+
+        if (utils.existsSync(__dirname + '/' + module + '.js') ||
+            utils.existsSync(__dirname + '/' + module)) {
+            return require(module);
+        }
+
+        return require(path.dirname(file_path) + '/' + module);
+    };
 };
 
 function client_disconnected (object) {

--- a/tests/node_modules/test-plugin/package.json
+++ b/tests/node_modules/test-plugin/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "test-plugin",
+    "version": "1.0.0",
+    "main": "./test-plugin.js"
+}

--- a/tests/node_modules/test-plugin/test-plugin.js
+++ b/tests/node_modules/test-plugin/test-plugin.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.hook_init_master = function (next) {
+  next();
+};

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -68,7 +68,7 @@ exports.get_plugin_paths = {
     setUp : _setUp,
 
     './path' : function (test) {
-        
+
         ['HARAKA', 'HARAKA_PLUGIN_PATH'].forEach(function (env) {
             delete process.env[env];
         });
@@ -97,12 +97,12 @@ exports.get_plugin_paths = {
     },
 
     'HARAKA' : function (test) {
-        
+
         ['HARAKA_PLUGIN_PATH'].forEach(function (env) {
             delete process.env[env];
         });
         process.env.HARAKA = '/etc/haraka';
-        
+
         test.expect(1);
         test.deepEqual(
             this.plugin._get_plugin_paths(),
@@ -124,7 +124,7 @@ exports.get_plugin_paths = {
         });
         process.env.HARAKA_PLUGIN_PATH = '/etc/haraka_plugins';
 
-        test.expect(1);        
+        test.expect(1);
         test.deepEqual(
             this.plugin._get_plugin_paths(),
             [
@@ -155,4 +155,33 @@ exports.get_plugin_paths = {
         );
         test.done();
     },
+};
+
+exports.load_plugins = {
+
+    setUp: function (done) {
+        process.env.HARAKA = __dirname;
+
+        this.orig_make_custom_require = plugin._make_custom_require;
+        plugin._make_custom_require = function (filePath, hasPackageJson) {
+            return function (module) {
+                return require(path.join(__dirname, 'node_modules', module));
+            }
+        };
+
+        this.plugin = plugin.load_plugin('test-plugin');
+        done();
+    },
+
+    tearDown: function (done) {
+        plugin._make_custom_require = this.orig_make_custom_require;
+        done();
+    },
+
+    'load from install directory node_modules': function (test) {
+        test.expect(1);
+        test.ok(this.plugin.hasOwnProperty('hook_init_master'));
+        test.done();
+    },
+
 };


### PR DESCRIPTION
* move custom require to a seperate function
* add make_custom_require so the function used to require code in the sandbox can be mocked out for testing.
* change name of make_custom_require to show it as private
* don't ignore the test node_modules
* test to load plugin from install directory node_modules

This is merely #1060 squashed. Closes #1060