### PR TITLE
Bumped version of node-syslog to fix build error on node v0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sprintf-js"    : "~1.0.2"
   },
   "optionalDependencies": {
-    "node-syslog": "~1.1.7",
+    "node-syslog": "~1.2.0",
     "strong-fork-syslog": "~1.2.3",
     "ldapjs": "~0.7.1",
     "vs-stun": "~0.0.7",


### PR DESCRIPTION
Bump to 1.2.0 for node-syslog to prevent error when installing using node v0.12. 