### PR TITLE
Fix distance reporting to X-Haraka-GeoIP for geoip-lite

### DIFF
--- a/plugins/connect.geoip.js
+++ b/plugins/connect.geoip.js
@@ -182,7 +182,7 @@ exports.lookup_geoip = function (next, connection) {
     }
 
     plugin.calculate_distance(connection, r.ll, function (err, distance) {
-        show.push(r.distance+'km');
+        show.push(distance+'km');
         connection.results.add(plugin, {human: show.join(', '), emit:true});
         return next();
     });


### PR DESCRIPTION
Currently reported as:

`"human": "US, MD, Baltimore, undefinedkm",`

and

`X-Haraka-GeoIP: US, MD, Baltimore, undefinedkm`