### PR TITLE
Move data_post hook timer into transaction object

### DIFF
--- a/transaction.js
+++ b/transaction.js
@@ -34,6 +34,8 @@ function Transaction() {
         tempfail: 0,
         reject:   0,
     };
+    this.data_post_start = null;
+    this.data_post_delay = 0;
 }
 
 exports.Transaction = Transaction;


### PR DESCRIPTION
The delay between the ending dot and when the message is accepted is a key statistic as most senders do not honour the RFC timer of 5 minutes for this phase, typically most senders timeouts are much shorter, so the delay must be kept to a minimum.

I've moved the recording and storage of this to the transaction object as it seemed the more logical place to keep it and so that this can be used later by a plugin e.g. one that logs the delay to a database.