### PR TITLE
Remove UUID from queued message

### DIFF
--- a/outbound.js
+++ b/outbound.js
@@ -476,7 +476,7 @@ exports.send_trans_email = function (transaction, next) {
         }
 
         if (next) {
-            next(constants.ok, "Message Queued (" + transaction.uuid + ")");
+            next(constants.ok, "Message Queued");
         }
     });
 };


### PR DESCRIPTION
Prevents this:

`250 Message Queued (9E4BCB7C-6006-451E-BA1D-7F80FCABBE72.1) (9E4BCB7C-6006-451E-BA1D-7F80FCABBE72.1)`

Due to the changes in https://github.com/baudehlo/Haraka/commit/167a65452b0d26db3b19cf3ecdef8bcc4f588231