### PR TITLE
Store HAProxy IP in connection object

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -213,6 +213,7 @@ function Connection(client, server) {
     this.errors = 0;
     this.last_rcpt_msg = null;
     this.hook = null;
+    this.haproxy_ip = null;
     setupClient(this);
 }
 
@@ -1134,6 +1135,7 @@ Connection.prototype.cmd_proxy = function (line) {
         ' dst_ip=' + dst_ip + ':' + dst_port);
 
     this.reset_transaction(function () {
+        self.haproxy_ip = self.remote_ip;
         self.relaying = false;
         self.local_ip = dst_ip;
         self.local_port = dst_port;

--- a/docs/Connection.md
+++ b/docs/Connection.md
@@ -29,6 +29,11 @@ If you have specified multiple listen= ports this variable is useful
 if you only want a plugin to run when connections are made to a specific
 port
 
+* connection.haproxy\_ip
+
+If the connection is being proxied by HAProxy, this variable will
+contain the remote IP address of the HAProxy host.
+
 * connection.greeting
 
 Either 'EHLO' or 'HELO' whichever the remote end used


### PR DESCRIPTION
Allows you to do something like this in a plugin:

`````
        // Do an A record lookup of the host name
        dns.resolve(host, 'A', function (err, addrs) {
            if (err) return next();
            if (addrs.indexOf(server.notes.public_ip) !== -1) {
                connection.loginfo(plugin, 'host matches public IP');
                return check_user();
            }
            if (addrs.indexOf(connection.haproxy_ip) !== -1) {
                connection.loginfo(plugin, 'host matches HAProxy IP');
                return check_user();
            }
            return next();
        });
````