### PR TITLE
TLS fixes: add timed_out flag and karma should not run deny hook on it.

### DIFF
--- a/plugins/karma.js
+++ b/plugins/karma.js
@@ -19,7 +19,7 @@ exports.register = function () {
     plugin.deny_exclude_hooks = utils.to_object('rcpt_to, queue');
     plugin.deny_exclude_plugins = utils.to_object(
             ['access', 'helo.checks', 'data.headers', 'spamassassin',
-            'mail_from.is_resolvable', 'clamd']
+            'mail_from.is_resolvable', 'clamd', 'tls']
     );
 
     plugin.load_karma_ini();


### PR DESCRIPTION
Fixes @celesteking issue as reported on IRC:

`````
11:28:28 - cek: [INFO] [E3540B59-60C2-4B0C-A98E-D232141349E7] [max_unrecognized_commands] max: 3, count: 0, fail:Unrecognized command: STARTTLS,
11:28:39 - cek:  [tls] timeout
11:28:57 - cek: [core] hook=unrecognized_command plugin=tls function=tls_unrecognized_command params="STARTTLS" retval=DENYSOFTDISCONNECT msg=""
11:29:07 - cek: [tls] secured: cipher=AES128-SHA version=TLSv1/SSLv3 verified=false error="Error: unable to get issuer certificate"
11:29:14 - cek: [core] tls plugin ran callback multiple times - ignoring subsequent calls
`````