### PR TITLE
Include dep installation step in git instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ First clone the repository:
     $ git clone https://github.com/baudehlo/Haraka.git
     $ cd Haraka
 
+Install Haraka's node.js dependencies locally:
+
+    $ npm install
+
 Edit `config/plugins` and `config/smtp.ini` to specify the plugins and
 config you want.
 


### PR DESCRIPTION
Installing Haraka with NPM directly takes care of dependencies, but before you can run it out of a git repo, you have to install dependencies.  I assume `npm install` (installing the deps locally rather than globally) is the preferred way to do this