### PR TITLE
more iojs compatible etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,22 @@ language: node_js
 node_js:
     - "0.12"
     - "0.10"
-#   - "0.8"   # no longer supported by iconv
-#   - "0.6"   # no longer supported by async
-    - "iojs-v1.8.1"
+    - "iojs-v1.8"
+    - "iojs-v2.5"
     - "iojs"
-
 services:
     - redis-server
-
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+env:
+  - "CXX=g++-4.8"
 matrix:
     allow_failures:
-        - node_js: "0.8"
         - node_js: "iojs"
-#       - node_js: "0.6"
-
 after_success:
     - npm run coveralls
-
 sudo: false

--- a/Changes
+++ b/Changes
@@ -46,6 +46,10 @@
     * added utils.node_min()
     * added result_store.get_all()
     * updated ubuntu upstart script
+	* update dependency versions (@Dexus)
+	* update optionaldependency versions (@Dexus)
+	* replace node-syslog with modern-syslog (@Dexus)
+	* replace redis with more stable ioredis (@Dexus)
 
 * Bug Fixes
     * corrected hook_rcpt log code hook_rcpt_ok returns CONT
@@ -64,6 +68,10 @@
     * connection: return 450/550 for plugin DENY* (was 452/552)
     * spamassassin: don't call next() when transaction gone
     * outbound: fix crash when sending bounce mail
+	* fix some tests (@Dexus)
+	* fix load_flat_config (@Dexus)
+	* fix ioredis multi result (@Dexus)
+	* fix typo and until.debug (Deprecated) => console.error (@Dexus)
 
 2.6.1 - Mar 27, 2015
 

--- a/configfile.js
+++ b/configfile.js
@@ -475,7 +475,7 @@ cfreader.load_flat_config = function(name, type) {
             var data   = fs.readFileSync(name, "UTF-8");
             if (type === 'data') {
                 while (data.length > 0) {
-                    var match = data.match(/^([^\n]*)\n?/);
+                    var match = data.match(/^([^\r\n]*)\r?\n?/);
                     result.push(match[1]);
                     data = data.slice(match[0].length);
                 }

--- a/docs/Results.md
+++ b/docs/Results.md
@@ -196,7 +196,7 @@ This is from the karma plugin, subscribing on the `connect_init` hook.
 ```js
 var redis = {
     patt: 'result-' + connection.uuid + '*',
-    conn: require('redis').createClient(),
+    conn: require('ioredis').createClient(),
 };
 redis.conn.on('psubscribe', function (pattern, count) {
     connection.loginfo(plugin, 'psubscribed to ' + pattern);

--- a/docs/plugins/dnsbl.md
+++ b/docs/plugins/dnsbl.md
@@ -31,7 +31,7 @@ dnsbl.ini - INI format with options described below:
 
 * enable\_stats
 
-    To use this feature you must have installed the 'redis' module and
+    To use this feature you must have installed the 'ioredis' module and
     have a redis server running.
 
     When enabled, this will record several list statistics to redis.

--- a/docs/plugins/dnswl.md
+++ b/docs/plugins/dnswl.md
@@ -36,7 +36,7 @@ dnswl.ini - INI format with options described below:
 
 * enable\_stats
 
-    To use this feature you must have installed the 'redis' module and
+    To use this feature you must have installed the 'ioredis' module and
     have a redis server running.
       
     When enabled, this will record several list statistics to redis.

--- a/docs/plugins/rate_limit.md
+++ b/docs/plugins/rate_limit.md
@@ -10,11 +10,11 @@ tarpit the connection by adding a delay before every response sent back to the
 client instead of sending a DENYSOFT.  To do this requires the 'tarpit' plugin 
 to run immediately after this plugin.
 
-To use this plugin you will need a Redis server and will need the redis, 
+To use this plugin you will need a Redis server and will need the ioredis, 
 hiredis and ipaddr.js packages installed via:
 
     cd /path/to/haraka/home
-    npm install redis hiredis ipaddr.js
+    npm install ioredis hiredis ipaddr.js
     
 Configuration
 -------------

--- a/docs/plugins/rcpt_to.routes.md
+++ b/docs/plugins/rcpt_to.routes.md
@@ -71,7 +71,7 @@ a 92,000 key object on a Xeon E5-2620 @ 2.10GHz.
 
 ## Redis
 
-The benchmarks published by the author(s) of the Node 'redis' module are
+The benchmarks published by the author(s) of the Node 'ioredis' module are
 about 30,000 qps.
 
 # Author

--- a/docs/plugins/redis.md
+++ b/docs/plugins/redis.md
@@ -1,6 +1,6 @@
 # redis
 
-Connects to a local (by default) redis instance and stores a `redis`
+Connects to a local (by default) redis instance and stores a `ioredis`
 connection handle at `server.notes.redis`. 
 
 ## Config

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "author": "Matt Sergeant <helpme@gmail.com> (http://baudehlo.com/)",
   "name": "Haraka",
   "description": "An SMTP Server project.",
-  "keywords": ["haraka", "smtp", "server", "email"],
+  "keywords": [
+    "haraka",
+    "smtp",
+    "server",
+    "email"
+  ],
   "version": "2.6.1",
   "homepage": "http://haraka.github.io",
   "repository": {
@@ -14,37 +19,37 @@
     "node": ">= v0.10.0"
   },
   "dependencies": {
-    "nopt"          : "~3.0.1",
-    "generic-pool"  : "~2.2.0",
-    "iconv"         : "~2.1.0",
-    "ipaddr.js"     : "~1.0.1",
-    "semver"        : "~2.2.1",
-    "async"         : "~1.1.0",
-    "daemon"        : "~1.1.0",
-    "npid"          : "~0.4.0",
-    "address-rfc2822":"~0.0.2",
-    "js-yaml"       : "~3.3.0",
-    "sprintf-js"    : "~1.0.2"
+    "address-rfc2822": "0.0.2",
+    "async": "^1.4.2",
+    "daemon": "^1.1.0",
+    "generic-pool": "^2.2.0",
+    "iconv": "^2.1.10",
+    "ipaddr.js": "^1.0.3",
+    "js-yaml": "^3.4.0",
+    "nopt": "^3.0.3",
+    "npid": "^0.4.0",
+    "semver": "^5.0.1",
+    "sprintf-js": "^1.0.3"
   },
   "optionalDependencies": {
-    "node-syslog": "~1.2.0",
-    "strong-fork-syslog": "~1.2.3",
-    "ldapjs": "~0.7.1",
-    "vs-stun": "~0.0.7",
-    "maxmind": "*",
-    "redis": "~0.10.1",
-    "tmp": "~0.0.24",
+    "elasticsearch": "*",
     "haraka-nosql": "*",
-    "elasticsearch": "*"
+    "hiredis": "^0.4.1",
+    "ioredis": "^1.7.6",
+    "ldapjs": "^0.7.1",
+    "maxmind": "*",
+    "modern-syslog": "^1.1.0",
+    "tmp": "0.0.27",
+    "vs-stun": "0.0.7"
   },
   "devDependencies": {
-    "nodeunit"      : "https://github.com/godsflaw/nodeunit/archive/master.tar.gz",
-    "jscoverage"    : "*",
-    "coveralls"     : "*",
-    "grunt"         : "*",
-    "grunt-contrib-clean" : "*",
-    "grunt-contrib-jshint" : "*",
-    "grunt-version-check" : "*"
+    "nodeunit": "https://github.com/godsflaw/nodeunit/archive/master.tar.gz",
+    "jscoverage": "*",
+    "coveralls": "*",
+    "grunt": "*",
+    "grunt-contrib-clean": "*",
+    "grunt-contrib-jshint": "*",
+    "grunt-version-check": "*"
   },
   "licenses": [
     {

--- a/plugins/dns_list_base.js
+++ b/plugins/dns_list_base.js
@@ -82,7 +82,7 @@ exports.stats_incr_zone = function (err, zone, start) {
 exports.init_redis = function () {
     if (redis_client) { return; }
 
-    var redis = require('redis');
+    var redis = require('ioredis');
     var host_port = this.redis_host.split(':');
     var host = host_port[0] || '127.0.0.1';
     var port = parseInt(host_port[1], 10) || 6379;

--- a/plugins/karma.js
+++ b/plugins/karma.js
@@ -1,7 +1,7 @@
 'use strict';
 // karma - reward good and penalize bad mail senders
 
-var redis  = require('redis');
+var redis  = require('ioredis');
 
 var utils  = require('./utils');
 
@@ -85,7 +85,7 @@ exports.results_init = function (next, connection) {
     // result_store is publishing conn results, time to listen
     var redis = {
         patt: 'result-' + connection.uuid + '*',
-        conn: require('redis').createClient(),
+        conn: require('ioredis').createClient(),
     };
     redis.conn.on('psubscribe', function (pattern, count) {
         connection.logdebug(plugin, 'psubscribed to ' + pattern);

--- a/plugins/log.syslog.js
+++ b/plugins/log.syslog.js
@@ -4,16 +4,10 @@
 exports.register = function() {
     var plugin = this;
 
-    try { plugin.Syslog = require('node-syslog'); }
+    try { plugin.Syslog = require('modern-syslog'); }
     catch (e) {
-        plugin.logerror('failed to load node-syslog');
-
-        try { plugin.Syslog = require('strong-fork-syslog'); }
-        catch (e) {
-            plugin.logerror("couldn't load strong-fork-syslog either");
-            plugin.logerror('try: npm i node-syslog strong-fork-syslog' );
-            return;
-        }
+        plugin.logerror('failed to load modern-syslog');
+        return;
     }
 
     var options   = 0;

--- a/plugins/rate_limit.js
+++ b/plugins/rate_limit.js
@@ -1,6 +1,6 @@
 // rate_limit
 var ipaddr = require('ipaddr.js');
-var redis = require('redis');
+var redis = require('ioredis');
 var client;
 
 exports.register = function () {

--- a/plugins/rcpt_to.routes.js
+++ b/plugins/rcpt_to.routes.js
@@ -12,7 +12,7 @@ exports.register = function() {
 
     plugin.load_config();
 
-    try { redis = require('redis'); }
+    try { redis = require('ioredis'); }
     catch (e) {
         plugin.logerror("unable to load redis.\ndid you: npm install -g redis?");
     }
@@ -84,11 +84,11 @@ exports.rcpt = function(next, connection, params) {
             }
 
             // got replies from Redis, any with an MX?
-            if (replies[0]) {
+            if (replies[0][1]) {
                 txn.results.add(plugin, {pass: 'redis.email'});
                 return next(OK);
             }
-            if (replies[1]) {
+            if (replies[1][1]) {
                 txn.results.add(plugin, {pass: 'redis.domain'});
                 return next(OK);
             }
@@ -138,8 +138,8 @@ exports.get_mx = function(next, hmail, domain) {
             }
 
             // got replies from Redis, any with an MX?
-            if (replies[0]) { return next(OK, replies[0]); }
-            if (replies[1]) { return next(OK, replies[1]); }
+            if (replies[0]) { return next(OK, replies[0][1]); }
+            if (replies[1]) { return next(OK, replies[1][1]); }
 
             return do_file_search(); // no redis record, try files
         });

--- a/plugins/redis.js
+++ b/plugins/redis.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var redis  = require('redis');
+var redis  = require('ioredis');
 
 exports.register = function () {
     var plugin = this;

--- a/spf.js
+++ b/spf.js
@@ -2,7 +2,6 @@
 // spf
 
 var dns = require('dns');
-var util = require('util');
 var ipaddr = require('ipaddr.js');
 
 // Constructor
@@ -143,7 +142,7 @@ SPF.prototype.expand_macros = function (str) {
 };
 
 SPF.prototype.log_debug = function (str) {
-    util.debug(str);
+    console.error('DEBUG:', str);
 };
 
 SPF.prototype.check_host = function (ip, domain, mail_from, cb) {

--- a/tests/plugins/karma.js
+++ b/tests/plugins/karma.js
@@ -7,7 +7,7 @@ var config           = require('../../config');
 var ResultStore      = require("../../result_store");
 
 try {
-    var redis = require('redis');
+    var redis = require('ioredis');
 }
 catch (e) {
     console.log(e + "\nunable to load redis, skipping tests");

--- a/tests/plugins/log.syslog.js
+++ b/tests/plugins/log.syslog.js
@@ -38,10 +38,10 @@ var _set_up = function (done) {
     }
 
     try {
-        this.plugin.Syslog = require('node-syslog');
+        this.plugin.Syslog = require('modern-syslog');
     }
     catch (e) {
-        console.log('unable to load node-syslog');
+        console.log('unable to load modern-syslog');
         return done();
     }
 

--- a/tests/plugins/rcpt_to.routes.js
+++ b/tests/plugins/rcpt_to.routes.js
@@ -166,14 +166,15 @@ exports.get_mx_redis = {
     'email address redis hit' : function (test) {
         if (this.plugin.redis_pings) {
             var addr = new Address('<matt@example.com>');
-            test.expect(2);
             this.plugin.insert_route('matt@example.com','192.168.2.1');
-            this.plugin.get_mx(function (rc, mx) {
+            test.expect(2);
+            var cb = function (rc, mx) {
                 test.equal(rc, OK);
                 test.equal(mx, '192.168.2.1');
                 test.done();
                 this.plugin.delete_route(addr.address());
-            }, hmail, addr.host).bind(this);
+            }.bind(this);
+            this.plugin.get_mx(cb, hmail, addr.host);
         }
         else {
             test.expect(0);
@@ -183,8 +184,8 @@ exports.get_mx_redis = {
     'email domain redis hit' : function (test) {
         if (this.plugin.redis_pings) {
             var addr = new Address('<matt@example.com>');
-            test.expect(2);
             this.plugin.insert_route(addr.address(),'192.168.2.2');
+            test.expect(2);
             var cb = function (rc, mx) {
                 test.equal(rc, OK);
                 test.equal(mx, '192.168.2.2');
@@ -204,15 +205,13 @@ exports.get_mx_redis = {
             this.plugin.insert_route('matt@example.com','192.168.2.1');
             this.plugin.insert_route(     'example.com','192.168.2.2');
             var addr = new Address('<matt@example.com>');
-
             var cb = function (rc, mx) {
                 test.equal(rc, OK);
                 test.equal(mx, '192.168.2.1');
                 test.done();
                 this.plugin.delete_route('matt@example.com');
-                this.plugin.delete_route(     'example.com');
+                this.plugin.delete_route('example.com');
             }.bind(this);
-
             this.plugin.get_mx(cb, hmail, addr.host);
         }
         else {


### PR DESCRIPTION
Make iojs v1,v2,v3 compatible. 

* update dependency versions (@Dexus)
* update optionaldependency versions (@Dexus)
* replace node-syslog with modern-syslog (@Dexus)
* replace redis with more stable ioredis (@Dexus)

* fix load_flat_config
* fix ioredis multi result
* fix tests
* fix typo

* update _travis.yml allow iojs 3.x to fail
* fix until.debug => console.error

* Changes
* Typo & Clean Up

Update .travis.yml

Update package.json

remove redis from optionalDependencies

include smtp-code in bounce-reason string for upstream 5XX responses

When sending outbound email, the reason string in the Bounce-Message was missing STMP code and extended code for 5XX responses when not responded to the RCPT-TO command.