### PR TITLE
fcrdns: don't log error for ENODATA

### DIFF
--- a/plugins/connect.fcrdns.js
+++ b/plugins/connect.fcrdns.js
@@ -171,6 +171,7 @@ exports.handle_a_error = function(connection, err, domain) {
     switch (err.code) {
         case 'ENOTFOUND':
         case 'NXDOMAIN':
+        case 'ENODATA':
         case dns.NOTFOUND:
         case dns.NXDOMAIN:
             connection.results.add(plugin, {fail: 'ptr_valid('+domain+')' });


### PR DESCRIPTION
(now that every request is being made for IPv4 and IPv6, so at least one fails
on every request)