### PR TITLE
Fix tests and configfile parser

### DIFF
--- a/configfile.js
+++ b/configfile.js
@@ -475,7 +475,7 @@ cfreader.load_flat_config = function(name, type) {
             var data   = fs.readFileSync(name, "UTF-8");
             if (type === 'data') {
                 while (data.length > 0) {
-                    var match = data.match(/^([^\n]*)\n?/);
+                    var match = data.match(/^([^\r\n]*)\r?\n?/);
                     result.push(match[1]);
                     data = data.slice(match[0].length);
                 }

--- a/tests/plugins/rcpt_to.routes.js
+++ b/tests/plugins/rcpt_to.routes.js
@@ -168,12 +168,13 @@ exports.get_mx_redis = {
             var addr = new Address('<matt@example.com>');
             test.expect(2);
             this.plugin.insert_route('matt@example.com','192.168.2.1');
-            this.plugin.get_mx(function (rc, mx) {
+            var cb = function (rc, mx) {
                 test.equal(rc, OK);
                 test.equal(mx, '192.168.2.1');
                 test.done();
                 this.plugin.delete_route(addr.address());
-            }, hmail, addr.host).bind(this);
+            }.bind(this);
+            this.plugin.get_mx(cb, hmail, addr.host);
         }
         else {
             test.expect(0);


### PR DESCRIPTION
* Fix config flat files read and removes \r at line end - tests was before failed

* Fix test that wrong implemented for rcpt_to.routes.js