### PR TITLE
make sure server object is availabe to plugins loaded from node_modules

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -393,6 +393,7 @@ plugins._make_custom_require = function (file_path, hasPackageJson) {
         if (hasPackageJson) {
             var mod = require(module);
             constants.import(global);
+            global.server = plugins.server;
             return mod;
         }
 


### PR DESCRIPTION
This makes the server object available on plugins that were loaded from the Haraka config directory's node_modules.