### PR TITLE
Improve outbound testability

### DIFF
--- a/tests/fixtures/util_hmailitem.js
+++ b/tests/fixtures/util_hmailitem.js
@@ -1,0 +1,126 @@
+'use strict';
+
+var Address = require('../../address').Address;
+var stub_connection = require('./../fixtures/stub_connection');
+var transaction = require('../../transaction');
+var util = require('util');
+
+/**
+ * Creates a HMailItem instance for testing purpose
+ *
+ * @param outbound_context: The context of the outbound.js, e.g. from require('nodeunit').utils.sandbox("outbound.js")
+ * @param options
+ * @param callback(err, hmail)
+ */
+exports.createHMailItem = function (outbound_context, options, callback) {
+
+    var mail_from = options.mail_from || 'sender@domain';
+    var delivery_domain = options.delivery_domain || 'domain';
+    var mail_recipients = options.mail_recipients || [new Address('recipient@domain')];
+
+    var conn = stub_connection.createConnection();
+    conn.transaction = transaction.createTransaction('someuuid');
+    conn.transaction.mail_from = new Address(mail_from);
+
+    var todo = new outbound_context.TODOItem(delivery_domain, mail_recipients, conn.transaction);
+    todo.uuid = todo.uuid + '.' + 1;
+
+    var contents = [
+        "From: " + mail_from,
+        "To: " + mail_recipients.join(", "),
+        "MIME-Version: 1.0",
+        "Content-type: text/plain; charset=us-ascii",
+        "Subject: Some subject here",
+        "",
+        "Some email body here",
+        ""].join("\n");
+    var match;
+    var re = /^([^\n]*\n?)/;
+    while (match = re.exec(contents)) {
+        var line = match[1];
+        line = line.replace(/\r?\n?$/, '\r\n'); // make sure it ends in \r\n
+        conn.transaction.add_data(new Buffer(line));
+        contents = contents.substr(match[1].length);
+        if (contents.length === 0) {
+            break;
+        }
+    }
+    conn.transaction.message_stream.add_line_end();
+
+    var hmails = [];
+    var ok_paths = [];
+    outbound_context.exports.process_delivery(ok_paths, todo, hmails, function (err) {
+        if (err) {
+            callback('process_delivery error: ' + err);
+            return;
+        }
+        if (hmails.length == 0) {
+            callback('No hmail producted');
+            return;
+        }
+        for (var j=0; j<hmails.length; j++) {
+            var hmail = hmails[j];
+            hmail.hostlist = [ delivery_domain ];
+            callback(null, hmail);
+        }
+    });
+
+}
+
+/**
+ * runs a socket.write
+ * @param socket
+ * @param test
+ * @param playbook
+ */
+exports.playTestSmtpConversation = function(hmail, socket, test, playbook, callback) {
+    var testmx = {
+        bind_helo: "haraka.test",
+    };
+    hmail.try_deliver_host_on_socket(testmx, 'testhost', 'testport', socket);
+
+    socket.write = function (line) {
+        //console.log('MockSocket.write(' + line.replace(/\n/, '\\n').replace(/\r/, '\\r') + ')');
+        if (playbook.length == 0) {
+            test.ok(false, 'missing next playbook entry');
+            test.done();
+            return;
+        }
+        var expected;
+        while (false != (expected = getNextEntryFromPlaybook('haraka', playbook))) {
+            if (typeof expected.test === 'function') {
+                test.ok(expected.test(line), expected.description || 'Expected that line works with func: ' + expected.test);
+            } else {
+                test.equals(expected.test + '\r\n', line, expected.description || 'Expected that line equals: ' + expected.test);
+            }
+            if (expected.end_test === true) {
+                setTimeout(function () {
+                    callback();
+                }, 0);
+                return;
+            }
+        }
+        setTimeout(function () {
+            var nextMessageFromServer;
+            while (false != (nextMessageFromServer = getNextEntryFromPlaybook('remote', playbook))) {
+                socket.emit('line', nextMessageFromServer.line + '\r\n');
+            }
+        }, 0);
+    }
+
+    var welcome = getNextEntryFromPlaybook('remote', playbook);
+    socket.emit('line', welcome.line);
+
+}
+
+function getNextEntryFromPlaybook(ofType, playbook) {
+    if (playbook.length == 0) {
+        return false;
+    }
+    if (playbook[0].from == ofType) {
+        var entry = playbook.shift();
+        return entry;
+    }
+    return false;
+}
+

--- a/tests/outbound_protocol.js
+++ b/tests/outbound_protocol.js
@@ -1,0 +1,70 @@
+'use strict';
+
+require('../configfile').watch_files = false;
+var vm_harness = require('./fixtures/vm_harness');
+var fs = require('fs');
+var vm = require('vm');
+
+var config      = require('../config');
+var path        = require('path');
+var queue_dir = path.resolve(__dirname + '/test-queue/');
+
+var ensureTestQueueDirExists = function(done) {
+    fs.exists(queue_dir, function (exists) {
+        if (exists) {
+            done();
+        }
+        else {
+            fs.mkdir(queue_dir, function (err) {
+                if (err) {
+                    return done(err);
+                }
+                done();
+            });
+        }
+    });
+};
+
+var removeTestQueueDir = function(done) {
+    fs.exists(queue_dir, function (exists) {
+        if (exists) {
+            var files = fs.readdirSync(queue_dir);
+            files.forEach(function(file,index){
+                var curPath = queue_dir + "/" + file;
+                if (fs.lstatSync(curPath).isDirectory()) { // recurse
+                    return done(new Error('did not expect an sub folder here ("' + curPath + '")! cancel'));
+                }
+            });
+            files.forEach(function(file,index){
+                var curPath = queue_dir + "/" + file;
+                // console.log('unlinking ' + curPath);
+                fs.unlinkSync(curPath);
+            });
+            done();
+        }
+        else {
+            done();
+        }
+    });
+};
+
+exports.run_output_smtpcode_tests = {
+    setUp : ensureTestQueueDirExists,
+    tearDown : removeTestQueueDir,
+    'run basic outbound test in vm': function (test) {
+        var code = fs.readFileSync(__dirname + '/../outbound.js');
+        code += fs.readFileSync(__dirname + '/outbound_protocol/basic_outbound_trial_test.js');
+        var sandbox = {
+            require: vm_harness.sandbox_require,
+            console: console,
+            Buffer: Buffer,
+            exports: {},
+            process: process,
+            test: test,
+            setTimeout: setTimeout,
+            test_queue_dir: queue_dir, // will be injected into the test-module
+        };
+        vm.runInNewContext(code, sandbox);
+    }
+};
+

--- a/tests/outbound_protocol/basic_outbound_trial_test.js
+++ b/tests/outbound_protocol/basic_outbound_trial_test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+// This test file is executed by tests/outbound_protocol.js (see there)
+//
+// Important to understand the code: This is file is - for running the test - appended to outbound.js.
+
+
+test.expect(5);
+
+// What is tested:
+// A simple SMTP conversation is made
+// At one point, the mocked remote SMTP says "5XX", and we test that the HMailItem.bounce function gets called
+
+// we copy over here "test_queue_dir" from vm-sandbox to the queue_dir back
+// (queue_dir is outbound-private var introduced at the beginning of outbound.js)
+var queue_dir = test_queue_dir;
+
+var util_hmailitem = require('./../fixtures/util_hmailitem');
+var mock_sock      = require('./../fixtures/line_socket');
+
+// create a dummy HMailItem for testing
+util_hmailitem.createHMailItem(
+    {
+        TODOItem: TODOItem,
+        exports: exports,
+    }, // outbound context
+    {
+
+    },
+    function (err, hmail) {
+        if (err) {
+            test.ok(false, 'Could not create HMailItem: ' + err);
+            test.done();
+            return;
+        }
+        runBasicSmtpConversation(hmail);
+    }
+);
+
+var bounce_func_called = false;
+HMailItem.prototype.bounce = function (err, opts) {
+    test.ok(true, 'HMail bounce called');
+    bounce_func_called = true;
+}
+
+function runBasicSmtpConversation(hmail) {
+    if (!hmail.todo) {
+        hmail.once('ready', function () {
+            _runBasicSmtpConversation(hmail);
+        });
+    }
+    else {
+        _runBasicSmtpConversation(hmail);
+    }
+}
+function _runBasicSmtpConversation(hmail) {
+    var mock_socket = mock_sock.connect('testhost', 'testport');
+    mock_socket.writable = true;
+
+    // The playbook
+    // from remote: This line is to be sent (from an mocked remote SMTP) to haraka outbound. This is done in this test.
+    // from haraka: Expected answer from haraka-outbound to the mocked remote SMTP.
+    //              'test' can hold a function(line) returning true for success, or a string tested for equality
+    var testPlaybook = [
+        // Haraka connects, we say first
+        { 'from': 'remote', 'line': '220 testing-smtp' },
+
+        { 'from': 'haraka', 'test': function(line) { return line.match(/^EHLO /); }, 'description': 'Haraka should say EHLO', },
+        { 'from': 'remote', 'line': '220-testing-smtp' },
+        { 'from': 'remote', 'line': '220 8BITMIME' },
+
+        { 'from': 'haraka', 'test': 'MAIL FROM:<sender@domain>' },
+        { 'from': 'remote', 'line': '500 5.0.0 Absolutely not acceptable. Basic Test Only.' },
+
+        { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+    ];
+
+    util_hmailitem.playTestSmtpConversation(hmail, mock_socket, test, testPlaybook, function() {
+        test.ok(bounce_func_called, 'bounce function was called');
+        test.done();
+    });
+
+}
+
+


### PR DESCRIPTION
Mainly, introduced HMailItem.prototype.try_deliver_host_on_socket to be able to inject a mocked socket for testing

* a basic test on outbound.js triggering bounce
* Fix tests/outbound_protocol.js on node 0.10.40
* replaced hacky "this" in global context in call to util_hmailitem.createHMailItem by (hacky) explicit context.
* Fixed errorneus global in tearDown-func

* some code clean-up/code-style, docs/comments improved, fixed errorneus global
* PR squashed
* trailing whitespace cleanup (@msimerson)
* closes #1157 