### PR TITLE
Outbound.send_email: added dot-stuffing

### DIFF
--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -276,3 +276,10 @@ should queueing to disk fail e.g:
 
     outbound.send_email(from, to, contents);
 
+
+In case you are passing your content dot-stuffed (a dot at the start of a line
+is doubled, like it is in SMTP conversation, 
+see https://tools.ietf.org/html/rfc2821#section-4.5.2), you should pass the
+```dot_stuffed: true``` option, like so:
+    
+    outbound.send_email(from, to, contents, outnext, { dot_stuffed: true });

--- a/outbound.js
+++ b/outbound.js
@@ -355,6 +355,9 @@ exports.send_email = function () {
         to   = arguments[1],
         contents = arguments[2];
     var next = arguments[3];
+    var options = arguments[4];
+
+    var dot_stuffed = ((options && options.dot_stuffed) ? options.dot_stuffed : false);
 
     this.loginfo("Sending email via params");
 
@@ -408,6 +411,9 @@ exports.send_email = function () {
     while (match = re.exec(contents)) {
         var line = match[1];
         line = line.replace(/\r?\n?$/, '\r\n'); // make sure it ends in \r\n
+        if (dot_stuffed === false && line.length > 3 && line.substr(0,1) === '.') {
+            line = "." + line;
+        }
         transaction.add_data(new Buffer(line));
         contents = contents.substr(match[1].length);
         if (contents.length === 0) {


### PR DESCRIPTION
Outbound.send_email: added dot_stuffed option + doc

renamed option "dot_stuffing" to "dot_stuffed", default false. Enabling it would strip leading dots in content-lines.
added documentation for the new send_email option to enable passing already dot_stuffed content

closes #1165 