### PR TITLE
rate_limit plugin config need default uncommented

### DIFF
--- a/config/rate_limit.ini
+++ b/config/rate_limit.ini
@@ -15,33 +15,38 @@
 ; yahoo.com = 20
 ; google.com = 20
 
-; default = 5
+default = 5
 
 [rate_conn]
 ; Maximum number of connections from an IP or host over an interval
 
 127 = 0
-; default = 5  ; no interval defaults to 60s
+
+; no interval defaults to 60s
+default = 5
+
 
 [rate_rcpt_host]
 ; Maximum number of recipients from an IP or host over an interval
 
 127 = 0
-; default = 50/5m  ; 50 RCPT To: maximum in 5 minutes
+
+; 50 RCPT To: maximum in 5 minutes
+default = 50/5m
 
 [rate_rcpt_sender]
 ; Maximum number of recipients from a sender over an interval
 
 127 = 0
-; default = 50/5m
+default = 50/5m
 
 [rate_rcpt]
 ; Limit the rate of message attempts over a interval to a recipient
 
 127 = 0
-; default = 50/5m
+default = 50/5m
 
 [rate_rcpt_null]
 ; Limit the number of DSN/MDN messages by recipient
 
-; default = 1
+default = 1


### PR DESCRIPTION
comments not in same line as key = value; comments must be a row above to be entered

closes #1104 