### PR TITLE
Outbound Bounce messages according to RFC3464

### DIFF
--- a/config/outbound.bounce_message
+++ b/config/outbound.bounce_message
@@ -11,6 +11,3 @@ This is a permanent error; I've given up. Sorry it didn't work out.
 
 Intended Recipients: {recipients}
 Failure Reason: {reason}
-
---- Below this line is a copy of the message.
-

--- a/tests/fixtures/util_hmailitem.js
+++ b/tests/fixtures/util_hmailitem.js
@@ -5,6 +5,38 @@ var stub_connection = require('./../fixtures/stub_connection');
 var transaction = require('../../transaction');
 var util = require('util');
 
+
+/**
+ * Creates a HMailItem instance, which is passed to callback. Reports error on test param if creation fails.
+ *
+ * @param outbound_context
+ * @param test
+ * @param options
+ * @param callback
+ */
+exports.newMockHMailItem = function (outbound_context, test, options, callback) {
+    var opts = options || {};
+    exports.createHMailItem(
+        outbound_context,
+        opts,
+        function (err, hmail) {
+            if (err) {
+                test.ok(false, 'Could not create HMailItem: ' + err);
+                test.done();
+                return;
+            }
+            if (!hmail.todo) {
+                hmail.once('ready', function () {
+                    process.nextTick(function(){callback(hmail);});
+                });
+            }
+            else {
+                callback(hmail);
+            }
+        }
+    );
+}
+
 /**
  * Creates a HMailItem instance for testing purpose
  *
@@ -76,6 +108,7 @@ exports.createHMailItem = function (outbound_context, options, callback) {
 exports.playTestSmtpConversation = function(hmail, socket, test, playbook, callback) {
     var testmx = {
         bind_helo: "haraka.test",
+        exchange: "remote.testhost",
     };
     hmail.try_deliver_host_on_socket(testmx, 'testhost', 'testport', socket);
 

--- a/tests/fixtures/vm_harness.js
+++ b/tests/fixtures/vm_harness.js
@@ -18,7 +18,7 @@ exports.sandbox_require = function (id) {
     return require(id);
 }
 
-function make_test(module_path, test_path) {
+function make_test(module_path, test_path, additional_sandbox) {
     return function (test) {
         var code = fs.readFileSync(module_path);
         code += fs.readFileSync(test_path);
@@ -29,13 +29,17 @@ function make_test(module_path, test_path) {
             exports: {},
             test: test
         };
+        Object.keys(additional_sandbox).forEach(function (k) {
+            sandbox[k] = additional_sandbox[k];
+        });
         vm.runInNewContext(code, sandbox);
     };
 }
 
-exports.add_tests = function (module_path, tests_path, test_exports) {
+exports.add_tests = function (module_path, tests_path, test_exports, add_to_sandbox) {
+    var additional_sandbox = add_to_sandbox || {};
     var tests = fs.readdirSync(tests_path).filter(dot_files);
     for (var x = 0; x < tests.length; x++) {
-        test_exports[tests[x]] = make_test(module_path, tests_path + tests[x]);
+        test_exports[tests[x]] = make_test(module_path, tests_path + tests[x], additional_sandbox);
     }
 };

--- a/tests/outbound_protocol.js
+++ b/tests/outbound_protocol.js
@@ -1,12 +1,13 @@
 'use strict';
 
 require('../configfile').watch_files = false;
-var vm_harness = require('./fixtures/vm_harness');
-var fs = require('fs');
-var vm = require('vm');
+var vm_harness     = require('./fixtures/vm_harness');
+var fs             = require('fs');
+var vm             = require('vm');
+var config         = require('../config');
+var path           = require('path');
+var util_hmailitem = require('./fixtures/util_hmailitem');
 
-var config      = require('../config');
-var path        = require('path');
 var queue_dir = path.resolve(__dirname + '/test-queue/');
 
 var ensureTestQueueDirExists = function(done) {
@@ -25,7 +26,7 @@ var ensureTestQueueDirExists = function(done) {
     });
 };
 
-var removeTestQueueDir = function(done) {
+var removeTestQueueDir = function (done) {
     fs.exists(queue_dir, function (exists) {
         if (exists) {
             var files = fs.readdirSync(queue_dir);
@@ -37,7 +38,6 @@ var removeTestQueueDir = function(done) {
             });
             files.forEach(function(file,index){
                 var curPath = queue_dir + "/" + file;
-                // console.log('unlinking ' + curPath);
                 fs.unlinkSync(curPath);
             });
             done();
@@ -48,23 +48,17 @@ var removeTestQueueDir = function(done) {
     });
 };
 
-exports.run_output_smtpcode_tests = {
+exports.outbound_protocol_tests = {
     setUp : ensureTestQueueDirExists,
     tearDown : removeTestQueueDir,
-    'run basic outbound test in vm': function (test) {
-        var code = fs.readFileSync(__dirname + '/../outbound.js');
-        code += fs.readFileSync(__dirname + '/outbound_protocol/basic_outbound_trial_test.js');
-        var sandbox = {
-            require: vm_harness.sandbox_require,
-            console: console,
-            Buffer: Buffer,
-            exports: {},
-            process: process,
-            test: test,
-            setTimeout: setTimeout,
-            test_queue_dir: queue_dir, // will be injected into the test-module
-        };
-        vm.runInNewContext(code, sandbox);
-    }
 };
 
+vm_harness.add_tests(
+    path.join(__dirname, '/../outbound.js'),
+    path.join(__dirname, 'outbound_protocol/'),
+    exports.outbound_protocol_tests,
+    {
+        test_queue_dir: queue_dir,
+        process: process
+    }
+);

--- a/tests/outbound_protocol/basic_outbound_trial_test.js
+++ b/tests/outbound_protocol/basic_outbound_trial_test.js
@@ -5,7 +5,7 @@
 // Important to understand the code: This is file is - for running the test - appended to outbound.js.
 
 
-test.expect(5);
+test.expect(4);
 
 // What is tested:
 // A simple SMTP conversation is made
@@ -37,10 +37,9 @@ util_hmailitem.createHMailItem(
     }
 );
 
-var bounce_func_called = false;
 HMailItem.prototype.bounce = function (err, opts) {
     test.ok(true, 'HMail bounce called');
-    bounce_func_called = true;
+    test.done();
 }
 
 function runBasicSmtpConversation(hmail) {
@@ -76,8 +75,7 @@ function _runBasicSmtpConversation(hmail) {
     ];
 
     util_hmailitem.playTestSmtpConversation(hmail, mock_socket, test, testPlaybook, function() {
-        test.ok(bounce_func_called, 'bounce function was called');
-        test.done();
+        // test done covered in stubbed HMailItem.bounce
     });
 
 }

--- a/tests/outbound_protocol/outbound_bounce_net_errors.js
+++ b/tests/outbound_protocol/outbound_bounce_net_errors.js
@@ -1,0 +1,131 @@
+'use strict';
+
+test.expect(14);
+
+// What is tested:
+// - get_mx plugin with DENY/DENYSOFT is simulated
+// - found_mx with various errors is simulated
+// - try_deliver with empty hmail.mxlist is called
+// and it is tested that bounce/temp_fail gets called with DSN-params set
+
+// we copy over here "test_queue_dir" from vm-sandbox to the queue_dir back
+// (queue_dir is outbound-private var introduced at the beginning of outbound.js)
+var queue_dir = test_queue_dir;
+
+var util_hmailitem = require('./../fixtures/util_hmailitem');
+var async          = require('async');
+var dns            = require('dns');
+
+
+var outbound_context = {
+    TODOItem: exports.TODOItem,
+    exports: exports,
+};
+
+async.series(
+    [
+        // test get-mx-deny triggers bounce(...)
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                var orig_bounce = HMailItem.prototype.bounce;
+                HMailItem.prototype.bounce = function (err, opts) {
+                    test.ok(true, 'get_mx=DENY: bounce function called');
+                    /* dsn_code: 550,
+                     dsn_status: '5.1.2',
+                     dsn_action: 'failed' */
+                    test.equal('5.1.2', this.todo.rcpt_to[0].dsn_status, 'get_mx=DENY dsn status = 5.1.2');
+                }
+                mock_hmail.domain = mock_hmail.todo.domain;
+                HMailItem.prototype.get_mx_respond.apply(mock_hmail, [constants.deny, {}]);
+                HMailItem.prototype.bounce = orig_bounce;
+                callback(null, 1);
+            });
+        },
+        // test get-mx-denysoft triggers temp_fail(...)
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                var orig_temp_fail = HMailItem.prototype.temp_fail;
+                HMailItem.prototype.temp_fail = function (err, opts) {
+                    test.ok(true, 'get_mx-DENYSOFT: temp_fail function called');
+                    /*dsn_code: 450,
+                     dsn_status: '4.1.2',
+                     dsn_action: 'delayed' */
+                    test.equal('4.1.2', this.todo.rcpt_to[0].dsn_status, 'get_mx=DENYSOFT dsn status = 4.1.2');
+                }
+                mock_hmail.domain = mock_hmail.todo.domain;
+                HMailItem.prototype.get_mx_respond.apply(mock_hmail, [constants.denysoft, {}]);
+                HMailItem.prototype.temp_fail = orig_temp_fail;
+                callback(null, 1);
+            });
+        },
+        // test found_mx({code:dns.NXDOMAIN}) triggers bounce(...)
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                var orig_bounce = HMailItem.prototype.bounce;
+                HMailItem.prototype.bounce = function (err, opts) {
+                    test.ok(true, 'found_mx({code: dns.NXDOMAIN}): bounce function called');
+                    test.equal('5.1.2', this.todo.rcpt_to[0].dsn_status, 'found_mx({code: dns.NXDOMAIN}: dsn status = 5.1.2');
+                }
+                HMailItem.prototype.found_mx.apply(mock_hmail, [{code: dns.NXDOMAIN}, {}]);
+                HMailItem.prototype.bounce = orig_bounce;
+                callback(null, 1);
+            });
+        },
+        // test found_mx({code:'NOMX'}) triggers bounce(...)
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                var orig_bounce = HMailItem.prototype.bounce;
+                HMailItem.prototype.bounce = function (err, opts) {
+                    test.ok(true, 'found_mx({code: "NOMX"}): bounce function called');
+                    test.equal('5.1.2', this.todo.rcpt_to[0].dsn_status, 'found_mx({code: "NOMX"}: dsn status = 5.1.2');
+                }
+                HMailItem.prototype.found_mx.apply(mock_hmail, [{code: 'NOMX'}, {}]);
+                HMailItem.prototype.bounce = orig_bounce;
+                callback(null, 1);
+            });
+        },
+        // test found_mx({code:'SOME-OTHER-ERR'}) triggers temp_fail(...)
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                var orig_temp_fail = HMailItem.prototype.temp_fail;
+                HMailItem.prototype.temp_fail = function (err, opts) {
+                    test.ok(true, 'found_mx({code: "SOME-OTHER-ERR"}): temp_fail function called');
+                    test.equal('4.1.0', this.todo.rcpt_to[0].dsn_status, 'found_mx({code: "SOME-OTHER-ERR"}: dsn status = 4.1.0');
+                }
+                HMailItem.prototype.found_mx.apply(mock_hmail, [{code: 'SOME-OTHER-ERR'}, {}]);
+                HMailItem.prototype.temp_fail = orig_temp_fail;
+                callback(null, 1);
+            });
+        },
+        // test found_mx(null, [{priority:0,exchange:''}]) triggers bounce(...)
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                var orig_bounce = HMailItem.prototype.bounce;
+                HMailItem.prototype.bounce = function (err, opts) {
+                    test.ok(true, 'found_mx(null, [{priority:0,exchange:""}]): bounce function called');
+                    test.equal('5.1.2', this.todo.rcpt_to[0].dsn_status, 'found_mx(null, [{priority:0,exchange:""}]): dsn status = 5.1.2');
+                }
+                HMailItem.prototype.found_mx.apply(mock_hmail, [null, [{priority:0,exchange:''}]]);
+                HMailItem.prototype.bounce = orig_bounce;
+                callback(null, 1);
+            });
+        },
+        // test try_deliver while hmail.mxlist=[] triggers bounce(...)
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                mock_hmail.mxlist = [];
+                var orig_temp_fail = HMailItem.prototype.temp_fail;
+                HMailItem.prototype.temp_fail = function (err, opts) {
+                    test.ok(true, 'try_deliver while hmail.mxlist=[]: temp_fail function called');
+                    test.equal('5.1.2', this.todo.rcpt_to[0].dsn_status, 'try_deliver while hmail.mxlist=[]: dsn status = 5.1.2');
+                }
+                HMailItem.prototype.try_deliver.apply(mock_hmail, []);
+                HMailItem.prototype.temp_fail = orig_temp_fail;
+                callback(null, 1);
+            });
+        },
+    ],
+    function (err, results) {
+        test.done();
+    }
+);

--- a/tests/outbound_protocol/outbound_bounce_rfc3464.js
+++ b/tests/outbound_protocol/outbound_bounce_rfc3464.js
@@ -1,0 +1,264 @@
+'use strict';
+
+test.expect(54);
+
+// What is tested:
+// A simple SMTP conversation is made
+// At one point, the mocked remote SMTP says "5XX" or "4XX"
+// and we test that outbound.send_email is called with a RFC3464 bounce message
+// (or, in case of 4XX: that temp_fail is called and dsn vars are available)
+
+// we copy over here "test_queue_dir" from vm-sandbox to the queue_dir back
+// (queue_dir is outbound-private var introduced at the beginning of outbound.js)
+var queue_dir = test_queue_dir;
+
+var util_hmailitem = require('./../fixtures/util_hmailitem');
+var mock_sock      = require('./../fixtures/line_socket');
+var async          = require('async');
+
+var outbound_context = {
+    TODOItem: exports.TODOItem,
+    exports: exports,
+};
+
+async.series(
+    [
+        // test that MAIL FROM responded with 500 5.0.0 triggers
+        // send_email() containing bounce msg with  our codes and message
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                var mock_socket = mock_sock.connect('testhost', 'testport');
+                mock_socket.writable = true;
+
+                var orig_send_email = exports.send_email;
+                exports.send_email = function (from, to, contents, cb, opts) {
+                    test.ok(true, 'outbound.send_email called');
+                    test.ok(contents.match(/^Content-type: message\/delivery-status/m), 'its a bounce report');
+                    test.ok(contents.match(/^Final recipient: rfc822;recipient@domain/m), 'bounce report contains final recipient');
+                    test.ok(contents.match(/^Action: failed/m), 'DATA-5XX: bounce report contains action field');
+                    test.ok(contents.match(/^Status: 5\.0\.0/m), 'bounce report contains status field with our ext. smtp code');
+                    test.ok(contents.match(/Absolutely not acceptable\. Basic Test Only\./), 'original upstream message available');
+                    exports.send_email = orig_send_email;
+                    callback(null, 1);
+                };
+
+                // The playbook
+                // from remote: This line is to be sent (from an mocked remote SMTP) to haraka outbound. This is done in this test.
+                // from haraka: Expected answer from haraka-outbound to the mocked remote SMTP.
+                //              'test' can hold a function(line) returning true for success, or a string tested for equality
+                var testPlaybook = [
+                    // Haraka connects, we say first
+                    { 'from': 'remote', 'line': '220 testing-smtp' },
+
+                    { 'from': 'haraka', 'test': function(line) { return line.match(/^EHLO /); }, 'description': 'Haraka should say EHLO', },
+                    { 'from': 'remote', 'line': '220-testing-smtp' },
+                    { 'from': 'remote', 'line': '220 8BITMIME' },
+
+                    { 'from': 'haraka', 'test': 'MAIL FROM:<sender@domain>' },
+                    { 'from': 'remote', 'line': '500 5.0.0 Absolutely not acceptable. Basic Test Only.' },
+
+                    { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+                ];
+
+                util_hmailitem.playTestSmtpConversation(mock_hmail, mock_socket, test, testPlaybook, function() {
+
+                });
+            });
+        },
+        // test that early response of 3XX triggers temp_fail
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                var mock_socket = mock_sock.connect('testhost', 'testport');
+                mock_socket.writable = true;
+
+                var orig_temp_fail = HMailItem.prototype.temp_fail;
+                HMailItem.prototype.temp_fail = function (err, opts) {
+                    test.ok(true, 'early-3XX: outbound.temp_fail called');
+                    test.equal('3.0.0', this.todo.rcpt_to[0].dsn_status, 'early-3XX: dsn status = 3.0.0');
+                    test.equal('delayed', this.todo.rcpt_to[0].dsn_action, 'early-3XX: dsn action = delayed');
+                    test.ok(this.todo.rcpt_to[0].dsn_smtp_response.match(/No time for you right now/), 'early-3XX: original upstream message available');
+                    HMailItem.prototype.temp_fail = orig_temp_fail;
+                    callback(null, 1);
+                };
+                var testPlaybook = [
+                    { 'from': 'remote', 'line': '220 testing-smtp' },
+
+                    { 'from': 'haraka', 'test': function(line) { return line.match(/^EHLO /); }, 'description': 'Haraka should say EHLO', },
+                    { 'from': 'remote', 'line': '220-testing-smtp' },
+                    { 'from': 'remote', 'line': '220 8BITMIME' },
+
+                    { 'from': 'haraka', 'test': 'MAIL FROM:<sender@domain>' },
+                    { 'from': 'remote', 'line': '300 3.0.0 No time for you right now' },
+
+                    { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+                ];
+
+                util_hmailitem.playTestSmtpConversation(mock_hmail, mock_socket, test, testPlaybook, function() {
+
+                });
+            });
+        },
+        // test that response of 4XX for RCPT-TO triggers temp_fail
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                var mock_socket = mock_sock.connect('testhost', 'testport');
+                mock_socket.writable = true;
+
+                var orig_temp_fail = HMailItem.prototype.temp_fail;
+                HMailItem.prototype.temp_fail = function (err, opts) {
+                    test.ok(true, 'RCPT-TO-4XX: outbound.temp_fail called');
+                    test.equal('4.0.0', this.todo.rcpt_to[0].dsn_status, 'RCPT-TO-4XX: dsn status = 4.0.0');
+                    test.equal('delayed', this.todo.rcpt_to[0].dsn_action, 'RCPT-TO-4XX: dsn action = delayed');
+                    test.ok(this.todo.rcpt_to[0].dsn_smtp_response.match(/Currently not available\. Try again later\./), 'RCPT-TO-4XX: original upstream message available');
+                    HMailItem.prototype.temp_fail = orig_temp_fail;
+                    callback(null, 1);
+                };
+                var testPlaybook = [
+                    { 'from': 'remote', 'line': '220 testing-smtp' },
+
+                    { 'from': 'haraka', 'test': function(line) { return line.match(/^EHLO /); }, 'description': 'Haraka should say EHLO', },
+                    { 'from': 'remote', 'line': '220-testing-smtp' },
+                    { 'from': 'remote', 'line': '220 8BITMIME' },
+
+                    { 'from': 'haraka', 'test': 'MAIL FROM:<sender@domain>' },
+                    { 'from': 'remote', 'line': '250 2.1.0 Ok' },
+
+                    { 'from': 'haraka', 'test': 'RCPT TO:<recipient@domain>' },
+                    { 'from': 'remote', 'line': '400 4.0.0 Currently not available. Try again later.' },
+
+                    { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+                ];
+
+                util_hmailitem.playTestSmtpConversation(mock_hmail, mock_socket, test, testPlaybook, function() {
+
+                });
+            });
+        },
+
+        // test that response of 4XX for DATA triggers temp_fail
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                var mock_socket = mock_sock.connect('testhost', 'testport');
+                mock_socket.writable = true;
+
+                var orig_temp_fail = HMailItem.prototype.temp_fail;
+                HMailItem.prototype.temp_fail = function (err, opts) {
+                    test.ok(true, 'DATA-4XX: outbound.temp_fail called');
+                    test.equal('4.6.0', this.todo.rcpt_to[0].dsn_status, 'DATA-4XX: dsn status = 4.6.0');
+                    test.equal('delayed', this.todo.rcpt_to[0].dsn_action, 'DATA-4XX: dsn action = delayed');
+                    test.ok(this.todo.rcpt_to[0].dsn_smtp_response.match(/Currently I do not like ascii art cats\./), 'DATA-4XX: original upstream message available');
+                    HMailItem.prototype.temp_fail = orig_temp_fail;
+                    callback(null, 1);
+                };
+                var testPlaybook = [
+                    { 'from': 'remote', 'line': '220 testing-smtp' },
+
+                    { 'from': 'haraka', 'test': function(line) { return line.match(/^EHLO /); }, 'description': 'Haraka should say EHLO', },
+                    { 'from': 'remote', 'line': '220-testing-smtp' },
+                    { 'from': 'remote', 'line': '220 8BITMIME' },
+
+                    { 'from': 'haraka', 'test': 'MAIL FROM:<sender@domain>' },
+                    { 'from': 'remote', 'line': '250 2.1.0 Ok' },
+
+                    { 'from': 'haraka', 'test': 'RCPT TO:<recipient@domain>' },
+                    { 'from': 'remote', 'line': '250 2.1.5 Ok' },
+
+                    { 'from': 'haraka', 'test': 'DATA' },
+                    // haraka will send us more lines
+                    { 'from': 'remote', 'line': '450 4.6.0 Currently I do not like ascii art cats.' },
+
+                    { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+                ];
+
+                util_hmailitem.playTestSmtpConversation(mock_hmail, mock_socket, test, testPlaybook, function() {
+
+                });
+            });
+        },
+        // test that response of 5XX for RCPT-TO triggers
+        // send_email() containing bounce msg with  our codes and message
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                var mock_socket = mock_sock.connect('testhost', 'testport');
+                mock_socket.writable = true;
+
+                var orig_send_email = exports.send_email;
+                exports.send_email = function (from, to, contents, cb, opts) {
+                    test.ok(true, 'RCPT-TO-5XX: outbound.send_email called');
+                    test.ok(contents.match(/^Content-type: message\/delivery-status/m), 'RCPT-TO-5XX: its a bounce report');
+                    test.ok(contents.match(/^Final recipient: rfc822;recipient@domain/m), 'RCPT-TO-5XX:  bounce report contains final recipient');
+                    test.ok(contents.match(/^Action: failed/m), 'DATA-5XX: bounce report contains action field');
+                    test.ok(contents.match(/^Status: 5\.1\.1/m), 'RCPT-TO-5XX: bounce report contains status field with our ext. smtp code');
+                    test.ok(contents.match(/Not available and will not come back/), 'RCPT-TO-5XX: original upstream message available');
+                    exports.send_email = orig_send_email;
+                    callback(null, 1);
+                };
+                var testPlaybook = [
+                    { 'from': 'remote', 'line': '220 testing-smtp' },
+
+                    { 'from': 'haraka', 'test': function(line) { return line.match(/^EHLO /); }, 'description': 'Haraka should say EHLO', },
+                    { 'from': 'remote', 'line': '220-testing-smtp' },
+                    { 'from': 'remote', 'line': '220 8BITMIME' },
+
+                    { 'from': 'haraka', 'test': 'MAIL FROM:<sender@domain>' },
+                    { 'from': 'remote', 'line': '250 2.1.0 Ok' },
+
+                    { 'from': 'haraka', 'test': 'RCPT TO:<recipient@domain>' },
+                    { 'from': 'remote', 'line': '550 5.1.1 Not available and will not come back' },
+
+                    { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+                ];
+
+                util_hmailitem.playTestSmtpConversation(mock_hmail, mock_socket, test, testPlaybook, function() {
+
+                });
+            });
+        },
+        // test that response of 5XX for DATA triggers
+        // send_email() containing bounce msg with  our codes and message
+        function (callback) {
+            util_hmailitem.newMockHMailItem(outbound_context, test, {}, function(mock_hmail){
+                var mock_socket = mock_sock.connect('testhost', 'testport');
+                mock_socket.writable = true;
+
+                var orig_send_email = exports.send_email;
+                exports.send_email = function (from, to, contents, cb, opts) {
+                    test.ok(true, 'DATA-5XX: outbound.send_email called');
+                    test.ok(contents.match(/^Content-type: message\/delivery-status/m), 'DATA-5XX: its a bounce report');
+                    test.ok(contents.match(/^Final recipient: rfc822;recipient@domain/m), 'DATA-5XX:  bounce report contains final recipient');
+                    test.ok(contents.match(/^Action: failed/m), 'DATA-5XX: bounce report contains action field');
+                    test.ok(contents.match(/^Status: 5\.6\.0/m), 'DATA-5XX: bounce report contains status field with our ext. smtp code');
+                    test.ok(contents.match(/I never did and will like ascii art cats/), 'DATA-5XX: original upstream message available');
+                    exports.send_email = orig_send_email;
+                    callback(null, 1);
+                };
+                var testPlaybook = [
+                    { 'from': 'remote', 'line': '220 testing-smtp' },
+
+                    { 'from': 'haraka', 'test': function(line) { return line.match(/^EHLO /); }, 'description': 'Haraka should say EHLO', },
+                    { 'from': 'remote', 'line': '220-testing-smtp' },
+                    { 'from': 'remote', 'line': '220 8BITMIME' },
+
+                    { 'from': 'haraka', 'test': 'MAIL FROM:<sender@domain>' },
+                    { 'from': 'remote', 'line': '250 2.1.0 Ok' },
+
+                    { 'from': 'haraka', 'test': 'RCPT TO:<recipient@domain>' },
+                    { 'from': 'remote', 'line': '250 2.1.5 Ok' },
+
+                    { 'from': 'haraka', 'test': 'DATA' },
+                    // haraka will send us more lines
+                    { 'from': 'remote', 'line': '550 5.6.0 I never did and will like ascii art cats.' },
+
+                    { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+                ];
+
+                util_hmailitem.playTestSmtpConversation(mock_hmail, mock_socket, test, testPlaybook, function() {
+
+                });
+            });
+        },
+    ],
+    function (err, results) {
+        test.done();
+    }
+);


### PR DESCRIPTION
This PR adds bounce messages in RFC3464 format for outbound failures:

- config/outbound.bounce_message is used for the headers and the human-readable part
- bounce message contain original mail headers only
- re-uses dsn.js for errors before talking to remote-MTA
- uses remote-MTA codes on failures during SMTP conversation
- includes tests
- includes no docs except some lines in source
- reorganized outbound_protocol tests to reuse fixtures/vm_harness

Feedback welcome