### PR TITLE
Fix bug when client disconnect after sending data

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -44,6 +44,8 @@ var states = exports.states = {
     STATE_DISCONNECTED:    100,
 };
 
+var nextTick = setImmediate || process.nextTick;
+
 // copy logger methods into Connection:
 for (var key in logger) {
     if (!/^log\w/.test(key)) continue;
@@ -371,7 +373,7 @@ Connection.prototype._process_data = function() {
                 this.logdebug('[early_talker] state=' + this.state + ' esmtp=' + this.esmtp + ' line="' + this_line + '"');
             }
             this.early_talker = true;
-            self._process_data();
+            nextTick(self._process_data);
             break;
         }
         else if ((this.state === states.STATE_PAUSE || this.state === states.STATE_PAUSE_SMTP) && this.esmtp) {
@@ -412,7 +414,7 @@ Connection.prototype._process_data = function() {
                             ' esmtp=' + this.esmtp + ' line="' + this_line + '"');
                 }
                 this.early_talker = true;
-                self._process_data();
+                nextTick(self._process_data);
             }
             break;
         }

--- a/connection.js
+++ b/connection.js
@@ -373,7 +373,7 @@ Connection.prototype._process_data = function() {
                 this.logdebug('[early_talker] state=' + this.state + ' esmtp=' + this.esmtp + ' line="' + this_line + '"');
             }
             this.early_talker = true;
-            nextTick(self._process_data);
+            nextTick(function () { self._process_data() });
             break;
         }
         else if ((this.state === states.STATE_PAUSE || this.state === states.STATE_PAUSE_SMTP) && this.esmtp) {
@@ -414,7 +414,7 @@ Connection.prototype._process_data = function() {
                             ' esmtp=' + this.esmtp + ' line="' + this_line + '"');
                 }
                 this.early_talker = true;
-                nextTick(self._process_data);
+                nextTick(function () { self._process_data() });
             }
             break;
         }


### PR DESCRIPTION
Had a bug when someone connected, sent a message with \r\n and immediatly disconnected
[INFO] [A317A8ED-2076-4E22-B4F6-925884DF9241] [core] HAProxy: proto=TCP4 src_ip=94.125.160.157:34982 dst_ip=149.202.52.64:587
[CRIT] [-] [core] RangeError: Maximum call stack size exceeded
[CRIT] [-] [core]     at new Uint8Array (native)
[CRIT] [-] [core]     at Buffer.subarray (native)
[CRIT] [-] [core]     at Buffer.slice (buffer.js:574:23)
[CRIT] [-] [core]     at Connection._process_data (/data/src/Haraka/connection.js:357:43)
[CRIT] [-] [core]     at Connection._process_data (/data/src/Haraka/connection.js:374:18)

Fixed the problem by applying what master smf said :o